### PR TITLE
feat: add support for published items

### DIFF
--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -18,6 +18,10 @@ type Poster = {
   publishedAt: Date | null;
   created: Date;
   updated: Date;
+  posterMetadata: {
+    publisher: string | null;
+    publicationYear: number | null;
+  };
 };
 
 const posters = ref<Poster[]>([]);
@@ -99,6 +103,10 @@ if (error.value) {
 
                 <div class="flex items-center gap-2">
                   <UButton
+                    v-if="
+                      !poster.posterMetadata.publisher &&
+                      !poster.posterMetadata.publicationYear
+                    "
                     color="secondary"
                     variant="subtle"
                     label="Add additional publication information"

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -99,14 +99,20 @@ if (error.value) {
                       name="heroicons:presentation-chart-bar"
                       class="h-3 w-3"
                     />
-                    Published
+                    Published at
                     {{ dayjs(poster.publishedAt).format("MMMM D, YYYY") }}
+                    {{
+                      poster.posterMetadata.publisher
+                        ? `on ${poster.posterMetadata.publisher}`
+                        : ""
+                    }}
                   </span>
                 </div>
 
                 <div class="flex items-center gap-2">
                   <UButton
-                    v-if="poster.publishedAt &&
+                    v-if="
+                      poster.publishedAt &&
                       !poster.posterMetadata.publisher &&
                       !poster.posterMetadata.publicationYear
                     "

--- a/app/pages/share/[id]/index.vue
+++ b/app/pages/share/[id]/index.vue
@@ -102,6 +102,9 @@ if (data.value) {
       color: "warning",
     });
 
+    // open the discover page for this poster in a new tab
+    window.open(`/discover/${id}`, "_blank");
+
     await navigateTo("/dashboard");
 
     throw createError({

--- a/server/api/poster/index.get.ts
+++ b/server/api/poster/index.get.ts
@@ -5,6 +5,14 @@ export default defineEventHandler(async (event) => {
   const userId = user.id;
 
   const posters = await prisma.poster.findMany({
+    include: {
+      posterMetadata: {
+        select: {
+          publisher: true,
+          publicationYear: true,
+        },
+      },
+    },
     where: {
       userId,
     },

--- a/server/api/poster/index.get.ts
+++ b/server/api/poster/index.get.ts
@@ -12,19 +12,17 @@ export default defineEventHandler(async (event) => {
           publicationYear: true,
         },
       },
+      extractionJob: {
+        select: {
+          status: true,
+        },
+      },
     },
     where: {
       userId,
     },
     orderBy: {
       created: "desc",
-    },
-    include: {
-      extractionJob: {
-        select: {
-          status: true,
-        },
-      },
     },
   });
 

--- a/server/api/release/zenodo/simulated.post.ts
+++ b/server/api/release/zenodo/simulated.post.ts
@@ -37,10 +37,18 @@ export default defineEventHandler(async (event) => {
   }
 
   await prisma.poster.update({
-    where: { id: poster.id },
+    where: {
+      id: poster.id,
+    },
     data: {
       status: "published",
       publishedAt: new Date(),
+      posterMetadata: {
+        update: {
+          publisher: "Zenodo",
+          publicationYear: new Date().getFullYear(),
+        },
+      },
     },
   });
 

--- a/server/api/release/zenodo/simulated.post.ts
+++ b/server/api/release/zenodo/simulated.post.ts
@@ -36,17 +36,19 @@ export default defineEventHandler(async (event) => {
     });
   }
 
+  const now = new Date();
+
   await prisma.poster.update({
     where: {
       id: poster.id,
     },
     data: {
       status: "published",
-      publishedAt: new Date(),
+      publishedAt: now,
       posterMetadata: {
         update: {
           publisher: "Zenodo",
-          publicationYear: new Date().getFullYear(),
+          publicationYear: now.getFullYear(),
         },
       },
     },


### PR DESCRIPTION
## Summary by Sourcery

Update poster publishing flow to enrich metadata and improve navigation after publishing.

New Features:
- Automatically populate publisher and publication year metadata when simulating a Zenodo publication.
- Expose poster metadata (publisher and publication year) in the dashboard API and UI.
- Open the discover page for a poster in a new tab after completing the share workflow.

Enhancements:
- Hide the "Add additional publication information" action on the dashboard once publisher and publication year metadata are present.