### PR TITLE
feat: ✨  Upload poster file along with poster.json

### DIFF
--- a/app/pages/discover/[posterid]/index.vue
+++ b/app/pages/discover/[posterid]/index.vue
@@ -8,6 +8,7 @@ const posterId = route.params.posterid as string;
 
 const { loggedIn } = useUserSession();
 const toast = useToast();
+const { siteEnv } = useRuntimeConfig().public;
 
 const { data: apiData, error } = await useFetch(`/api/discover/${posterId}`);
 
@@ -19,6 +20,7 @@ const api = apiData.value as any;
 const conf = api?.conference;
 
 const liked = ref(api?.liked ?? false);
+
 const liking = ref(false);
 
 const poster = ref({
@@ -100,6 +102,19 @@ const poster = ref({
         : undefined,
     },
   },
+});
+
+const zenodoUrl = computed(() => {
+  if (!poster.value.doi) return null;
+  const isSandbox =
+    siteEnv === "staging" || siteEnv === "development" || siteEnv === "dev";
+  if (isSandbox) {
+    const recordId = poster.value.doi.split("/zenodo.")[1];
+
+    return `https://sandbox.zenodo.org/records/${recordId}`;
+  }
+
+  return `https://doi.org/${poster.value.doi}`;
 });
 
 const licenseInfo = computed(() => {
@@ -283,11 +298,7 @@ const tabItems = [
           </div>
 
           <div class="flex items-center gap-2">
-            <NuxtLink
-              v-if="poster.doi"
-              :to="`https://doi.org/${poster.doi}`"
-              target="_blank"
-            >
+            <NuxtLink v-if="zenodoUrl" :to="zenodoUrl" target="_blank">
               <UButton
                 color="primary"
                 variant="solid"

--- a/app/pages/share/[id]/review.vue
+++ b/app/pages/share/[id]/review.vue
@@ -223,9 +223,10 @@ watch(depositionMode, () => {
 
 const readyToArchive = computed(
   () =>
-    depositionMode.value === "new" ||
-    (depositionMode.value === "existing" &&
-      selectedDeposition.value !== undefined),
+    !!selectedLicense.value &&
+    (depositionMode.value === "new" ||
+      (depositionMode.value === "existing" &&
+        selectedDeposition.value !== undefined)),
 );
 
 // Archive progress state
@@ -726,7 +727,9 @@ async function handleArchive() {
 
               <!-- License selection -->
               <div class="mt-4">
-                <p class="text-muted mb-2 text-sm">License</p>
+                <p class="text-muted mb-2 text-sm">
+                  License <span class="text-error">*</span>
+                </p>
 
                 <USelectMenu
                   v-model="selectedLicense"
@@ -796,7 +799,9 @@ async function handleArchive() {
       <template v-else>
         <div class="mt-5 flex flex-col gap-4">
           <div>
-            <p class="text-muted mb-2 text-sm">License</p>
+            <p class="text-muted mb-2 text-sm">
+              License <span class="text-error">*</span>
+            </p>
 
             <USelectMenu
               v-model="selectedLicense"
@@ -812,6 +817,7 @@ async function handleArchive() {
             <UButton
               color="primary"
               size="lg"
+              :disabled="!selectedLicense"
               :loading="isSimulatedPublishing"
               @click="handleSimulatedArchive"
             >

--- a/app/pages/share/new.vue
+++ b/app/pages/share/new.vue
@@ -193,15 +193,6 @@ onUnmounted(() => {
       <UiSpinner :loading="status === 2 || isUploading" overlay>
         <UCard>
           <div class="space-y-6">
-            <!-- Maintenance Notice -->
-            <UAlert
-              color="warning"
-              variant="soft"
-              icon="i-heroicons-wrench-screwdriver"
-              title="Upload temporarily unavailable"
-              description="This feature is temporarily unavailable. Please check back soon."
-            />
-
             <UiFileUpload @on-change="selectedFiles = $event">
               <UiFileUploadGrid />
             </UiFileUpload>
@@ -261,7 +252,7 @@ onUnmounted(() => {
 
           <template #footer>
             <UButton
-              disabled
+              :disabled="isUploading"
               class="flex w-full justify-center"
               variant="outline"
               icon="i-heroicons-cloud-arrow-up-solid"

--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -407,25 +407,41 @@ export async function beginZenodoPublication(
     };
   }
 
-  const posterFileBuffer = await posterFileRes.arrayBuffer();
-  const posterFileBlob = new Blob([posterFileBuffer], {
-    type: "application/octet-stream",
-  });
+  const posterFileName = extractionJob.fileName || "poster.pdf";
+  const posterFileContentLength = posterFileRes.headers.get("Content-Length");
 
-  const posterFileUploadResult = await uploadFileToZenodoBucket(
-    bucketUrl,
-    tokenRecord.accessToken,
-    extractionJob.fileName || "poster.pdf",
-    posterFileBlob,
+  console.log(
+    `[Zenodo] Uploading poster file "${posterFileName}" to bucket: ${bucketUrl}`,
   );
 
-  if (!posterFileUploadResult.success) {
+  const posterFileUploadRes = await fetch(`${bucketUrl}/${posterFileName}`, {
+    method: "PUT",
+    // @ts-expect-error required when body is a ReadableStream
+    duplex: "half",
+    headers: {
+      "Content-Type": "application/octet-stream",
+      ...(posterFileContentLength
+        ? { "Content-Length": posterFileContentLength }
+        : {}),
+      Authorization: `Bearer ${tokenRecord.accessToken}`,
+    },
+    body: posterFileRes.body,
+  });
+
+  if (!posterFileUploadRes.ok) {
     console.log(
-      `[Zenodo] Failed to upload poster file: ${posterFileUploadResult.error}`,
+      `[Zenodo] Failed to upload poster file "${posterFileName}" (status: ${posterFileUploadRes.status})`,
     );
 
-    return { success: false, error: posterFileUploadResult.error };
+    const errorMsg = await getZenodoErrorMessage(
+      `Failed to upload file "${posterFileName}"`,
+      posterFileUploadRes,
+    );
+
+    return { success: false, error: errorMsg };
   }
+
+  console.log(`[Zenodo] Uploaded poster file "${posterFileName}" successfully`);
 
   await onProgress?.({
     step: "upload_files",
@@ -946,6 +962,7 @@ async function uploadFileToZenodoBucket(
       method: "PUT",
       headers: {
         "Content-Type": "application/octet-stream",
+        "Content-Length": String(content.size),
         Authorization: `Bearer ${zenodoToken}`,
       },
       body: content,

--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -374,7 +374,58 @@ export async function beginZenodoPublication(
     return { success: false, error: uploadResult.error };
   }
 
-  // TODO: Retrieve and upload poster file
+  // Retrieve and upload poster file
+  const extractionJob = await prisma.extractionJob.findUnique({
+    where: { posterId: posterInt },
+  });
+
+  if (!extractionJob?.filePath) {
+    console.log(
+      `[Zenodo] No extraction job or file path found for poster: ${posterId}`,
+    );
+
+    return { success: false, error: "Poster file not found for upload" };
+  }
+
+  console.log(
+    `[Zenodo] Fetching poster file from BunnyCDN: ${extractionJob.filePath}`,
+  );
+
+  const posterFileRes = await fetch(
+    `${config.bunnyPrivateStorage}/${extractionJob.filePath}`,
+    { headers: { AccessKey: config.bunnyPrivateStorageKey } },
+  );
+
+  if (!posterFileRes.ok) {
+    console.log(
+      `[Zenodo] Failed to fetch poster file from BunnyCDN: ${posterFileRes.status}`,
+    );
+
+    return {
+      success: false,
+      error: "Failed to retrieve poster file from storage",
+    };
+  }
+
+  const posterFileBuffer = await posterFileRes.arrayBuffer();
+  const posterFileBlob = new Blob([posterFileBuffer], {
+    type: "application/octet-stream",
+  });
+
+  const posterFileUploadResult = await uploadFileToZenodoBucket(
+    bucketUrl,
+    tokenRecord.accessToken,
+    extractionJob.fileName || "poster.pdf",
+    posterFileBlob,
+  );
+
+  if (!posterFileUploadResult.success) {
+    console.log(
+      `[Zenodo] Failed to upload poster file: ${posterFileUploadResult.error}`,
+    );
+
+    return { success: false, error: posterFileUploadResult.error };
+  }
 
   await onProgress?.({
     step: "upload_files",


### PR DESCRIPTION
## Summary by Sourcery

Upload the poster file to Zenodo alongside poster metadata and update the poster detail page to link correctly to Zenodo records in both sandbox and production environments.

New Features:
- Support uploading the poster file from BunnyCDN storage to the configured Zenodo bucket as part of the publication flow.
- Expose a computed Zenodo URL on the poster detail page that routes to sandbox records in non-production environments and DOI links otherwise.