### PR TITLE
feat: :sparkles: mobile version for /discover page

### DIFF
--- a/app/components/discover/PublishedDateFilter.vue
+++ b/app/components/discover/PublishedDateFilter.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import {
+  type CalendarDate,
+  DateFormatter,
+  getLocalTimeZone,
+} from "@internationalized/date";
+
+const modelValue = defineModel<{
+  start: CalendarDate | undefined;
+  end: CalendarDate | undefined;
+}>({ required: true });
+
+const props = defineProps<{
+  numberOfMonths?: number;
+}>();
+
+const df = new DateFormatter("en-US", { dateStyle: "medium" });
+
+function clear() {
+  modelValue.value = { start: undefined, end: undefined };
+}
+</script>
+
+<template>
+  <div>
+    <h4 class="mb-3 text-sm font-medium">Published</h4>
+
+    <div class="flex items-center gap-2">
+      <UPopover>
+        <UButton
+          color="neutral"
+          variant="outline"
+          size="sm"
+          icon="i-lucide-calendar"
+        >
+          <template v-if="modelValue.start">
+            <template v-if="modelValue.end">
+              {{ df.format(modelValue.start.toDate(getLocalTimeZone())) }}
+              -
+              {{ df.format(modelValue.end.toDate(getLocalTimeZone())) }}
+            </template>
+
+            <template v-else>
+              {{ df.format(modelValue.start.toDate(getLocalTimeZone())) }}
+            </template>
+          </template>
+
+          <template v-else> Pick a date </template>
+        </UButton>
+
+        <template #content>
+          <UCalendar
+            v-model="modelValue"
+            class="p-2"
+            :number-of-months="props.numberOfMonths ?? 2"
+            range
+          />
+        </template>
+      </UPopover>
+
+      <UButton
+        v-if="modelValue.start"
+        color="neutral"
+        variant="ghost"
+        size="sm"
+        icon="i-lucide-x"
+        @click="clear"
+      />
+    </div>
+  </div>
+</template>

--- a/app/pages/discover/index.vue
+++ b/app/pages/discover/index.vue
@@ -120,6 +120,9 @@ if (error.value) {
 }
 
 const totalFiltered = computed(() => total.value);
+
+const showMobileFilter = ref(false);
+const hasActiveFilters = computed(() => !!dateFilterValue.value.start);
 </script>
 
 <template>
@@ -140,7 +143,7 @@ const totalFiltered = computed(() => total.value);
     />
 
     <div class="flex gap-6">
-      <div :class="['block w-80 flex-shrink-0 transition-all duration-300']">
+      <div class="hidden w-80 flex-shrink-0 md:block">
         <UCard class="sticky top-4">
           <template #header>
             <div class="flex items-center justify-between">
@@ -214,6 +217,86 @@ const totalFiltered = computed(() => total.value);
       </div>
 
       <div class="min-w-0 flex-1">
+        <!-- Mobile filter toggle — hidden on md+ -->
+        <div class="mb-4 md:hidden">
+          <UButton
+            color="neutral"
+            variant="outline"
+            icon="i-lucide-sliders-horizontal"
+            :trailing-icon="
+              showMobileFilter ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'
+            "
+            class="w-full justify-between"
+            @click="showMobileFilter = !showMobileFilter"
+          >
+            <span class="flex items-center gap-2">
+              Filters
+              <UBadge v-if="hasActiveFilters" color="primary" size="xs"
+                >1</UBadge
+              >
+            </span>
+          </UButton>
+
+          <div v-show="showMobileFilter" class="mt-2 rounded-lg border p-4">
+            <h4 class="mb-3 text-sm font-medium">Published</h4>
+
+            <div class="flex items-center gap-2">
+              <UPopover>
+                <UButton
+                  color="neutral"
+                  variant="outline"
+                  size="sm"
+                  icon="i-lucide-calendar"
+                >
+                  <template v-if="dateFilterValue.start">
+                    <template v-if="dateFilterValue.end">
+                      {{
+                        df.format(
+                          dateFilterValue.start.toDate(getLocalTimeZone()),
+                        )
+                      }}
+                      -
+                      {{
+                        df.format(
+                          dateFilterValue.end.toDate(getLocalTimeZone()),
+                        )
+                      }}
+                    </template>
+
+                    <template v-else>
+                      {{
+                        df.format(
+                          dateFilterValue.start.toDate(getLocalTimeZone()),
+                        )
+                      }}
+                    </template>
+                  </template>
+
+                  <template v-else> Pick a date </template>
+                </UButton>
+
+                <template #content>
+                  <UCalendar
+                    v-model="dateFilterValue"
+                    class="p-2"
+                    :number-of-months="1"
+                    range
+                  />
+                </template>
+              </UPopover>
+
+              <UButton
+                v-if="dateFilterValue.start"
+                color="neutral"
+                variant="ghost"
+                size="sm"
+                icon="i-lucide-x"
+                @click="dateFilterValue = { start: undefined, end: undefined }"
+              />
+            </div>
+          </div>
+        </div>
+
         <div class="flex items-center gap-2 pb-4">
           <UInput
             v-model="searchQuery"

--- a/app/pages/discover/index.vue
+++ b/app/pages/discover/index.vue
@@ -1,10 +1,7 @@
 <script setup lang="ts">
 import dayjs from "dayjs";
-import {
-  type CalendarDate,
-  DateFormatter,
-  getLocalTimeZone,
-} from "@internationalized/date";
+import { getLocalTimeZone } from "@internationalized/date";
+import type { CalendarDate } from "@internationalized/date";
 
 const ogImage = `https://kalai.fairdataihub.org/api/generate?title=${encodeURIComponent("Discover Posters - Posters.science")}&description=${encodeURIComponent("Find and explore scientific posters on a variety of topics.")}&app=posters-science&org=fairdataihub`;
 
@@ -14,10 +11,6 @@ useSeoMeta({
   ogTitle: "Discover Posters - Posters.science",
   ogDescription: "Find and explore scientific posters on a variety of topics.",
   ogImage,
-});
-
-const df = new DateFormatter("en-US", {
-  dateStyle: "medium",
 });
 
 const dateFilterValue = shallowRef<{
@@ -152,66 +145,7 @@ const hasActiveFilters = computed(() => !!dateFilterValue.value.start);
           </template>
 
           <div class="space-y-6">
-            <div>
-              <h4 class="mb-3 text-sm font-medium">Published</h4>
-
-              <div class="flex items-center gap-2">
-                <UPopover>
-                  <UButton
-                    color="neutral"
-                    variant="outline"
-                    size="sm"
-                    icon="i-lucide-calendar"
-                  >
-                    <template v-if="dateFilterValue.start">
-                      <template v-if="dateFilterValue.end">
-                        {{
-                          df.format(
-                            dateFilterValue.start.toDate(getLocalTimeZone()),
-                          )
-                        }}
-                        -
-                        {{
-                          df.format(
-                            dateFilterValue.end.toDate(getLocalTimeZone()),
-                          )
-                        }}
-                      </template>
-
-                      <template v-else>
-                        {{
-                          df.format(
-                            dateFilterValue.start.toDate(getLocalTimeZone()),
-                          )
-                        }}
-                      </template>
-                    </template>
-
-                    <template v-else> Pick a date </template>
-                  </UButton>
-
-                  <template #content>
-                    <UCalendar
-                      v-model="dateFilterValue"
-                      class="p-2"
-                      :number-of-months="2"
-                      range
-                    />
-                  </template>
-                </UPopover>
-
-                <UButton
-                  v-if="dateFilterValue.start"
-                  color="neutral"
-                  variant="ghost"
-                  size="sm"
-                  icon="i-lucide-x"
-                  @click="
-                    dateFilterValue = { start: undefined, end: undefined }
-                  "
-                />
-              </div>
-            </div>
+            <DiscoverPublishedDateFilter v-model="dateFilterValue" />
           </div>
         </UCard>
       </div>
@@ -238,62 +172,10 @@ const hasActiveFilters = computed(() => !!dateFilterValue.value.start);
           </UButton>
 
           <div v-show="showMobileFilter" class="mt-2 rounded-lg border p-4">
-            <h4 class="mb-3 text-sm font-medium">Published</h4>
-
-            <div class="flex items-center gap-2">
-              <UPopover>
-                <UButton
-                  color="neutral"
-                  variant="outline"
-                  size="sm"
-                  icon="i-lucide-calendar"
-                >
-                  <template v-if="dateFilterValue.start">
-                    <template v-if="dateFilterValue.end">
-                      {{
-                        df.format(
-                          dateFilterValue.start.toDate(getLocalTimeZone()),
-                        )
-                      }}
-                      -
-                      {{
-                        df.format(
-                          dateFilterValue.end.toDate(getLocalTimeZone()),
-                        )
-                      }}
-                    </template>
-
-                    <template v-else>
-                      {{
-                        df.format(
-                          dateFilterValue.start.toDate(getLocalTimeZone()),
-                        )
-                      }}
-                    </template>
-                  </template>
-
-                  <template v-else> Pick a date </template>
-                </UButton>
-
-                <template #content>
-                  <UCalendar
-                    v-model="dateFilterValue"
-                    class="p-2"
-                    :number-of-months="1"
-                    range
-                  />
-                </template>
-              </UPopover>
-
-              <UButton
-                v-if="dateFilterValue.start"
-                color="neutral"
-                variant="ghost"
-                size="sm"
-                icon="i-lucide-x"
-                @click="dateFilterValue = { start: undefined, end: undefined }"
-              />
-            </div>
+            <DiscoverPublishedDateFilter
+              v-model="dateFilterValue"
+              :number-of-months="1"
+            />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary by Sourcery

Add a mobile-friendly filter experience to the /discover page while preserving the existing desktop filter layout.

New Features:
- Introduce a collapsible mobile filter panel with a toggle button on the /discover page.
- Display an indicator badge for active filters on mobile when a publish date filter is applied.

Enhancements:
- Hide the sidebar filter card on small screens and restrict it to medium and larger viewports to improve responsive layout.