### PR TITLE
feat: ✨ Author labels + funding info added to Zenodo metadata

### DIFF
--- a/app/pages/share/[id]/index.vue
+++ b/app/pages/share/[id]/index.vue
@@ -221,6 +221,24 @@ if (data.value) {
           }),
         };
       });
+      // Back-fill scheme URIs for data loaded from the API
+      state.creators.forEach((creator) => {
+        creator.nameIdentifiers?.forEach((ni) => {
+          if (!ni.schemeURI && ni.nameIdentifier?.includes("orcid.org")) {
+            ni.nameIdentifierScheme ||= "ORCID";
+            ni.schemeURI = "https://orcid.org";
+          }
+        });
+        creator.affiliation?.forEach((aff) => {
+          if (
+            !aff.schemeURI &&
+            aff.affiliationIdentifier?.includes("ror.org")
+          ) {
+            aff.affiliationIdentifierScheme ||= "ROR";
+            aff.schemeURI = "https://ror.org";
+          }
+        });
+      });
       console.log("Transformed creators", state.creators);
     }
 
@@ -525,6 +543,32 @@ function removeRow<T>(arr: T[], index: number) {
   arr.splice(index, 1);
 }
 
+function handleAffiliationIdentifierInput(
+  value: string,
+  cIndex: number,
+  aIndex: number,
+) {
+  const aff = state.creators[cIndex]?.affiliation?.[aIndex];
+  if (!aff) return;
+  if (value.includes("ror.org")) {
+    aff.affiliationIdentifierScheme = "ROR";
+    aff.schemeURI = "https://ror.org";
+  }
+}
+
+function handleNameIdentifierInput(
+  value: string,
+  cIndex: number,
+  niIndex: number,
+) {
+  const ni = state.creators[cIndex]?.nameIdentifiers?.[niIndex];
+  if (!ni) return;
+  if (value.includes("orcid.org")) {
+    ni.nameIdentifierScheme = "ORCID";
+    ni.schemeURI = "https://orcid.org";
+  }
+}
+
 async function addSubjectAndFocus() {
   state.subjects.push("");
   await nextTick();
@@ -672,6 +716,14 @@ async function addSubjectAndFocus() {
               :key="cIndex"
               class="space-y-4 rounded-xl border border-gray-200 p-4"
             >
+              <div
+                class="bg-primary-50 inline-flex items-center rounded-md px-3 py-1"
+              >
+                <p class="text-primary-700 text-base font-medium">
+                  Author {{ cIndex + 1 }}
+                </p>
+              </div>
+
               <div class="flex items-start justify-between gap-3">
                 <UFormField
                   :name="`creators.${cIndex}.givenName`"
@@ -724,6 +776,111 @@ async function addSubjectAndFocus() {
                   Delete Creator
                 </UButton>
               </div>
+
+              <UFormField
+                label="Creator Identifiers (e.g., ORCID)"
+                name="nameIdentifiers"
+              >
+                <div
+                  v-if="
+                    state.creators[cIndex]?.nameIdentifiers &&
+                    state.creators[cIndex]?.nameIdentifiers?.length > 0
+                  "
+                >
+                  <div
+                    v-for="(ni, niIndex) in state.creators[cIndex]
+                      ?.nameIdentifiers"
+                    :key="niIndex"
+                    class="mb-2 space-y-2 rounded-xl border border-gray-200 p-3"
+                  >
+                    <div class="flex gap-2">
+                      <UFormField
+                        class="w-40 shrink-0"
+                        :name="`creators.${cIndex}.nameIdentifiers.${niIndex}.nameIdentifierScheme`"
+                        label="Identifier Type"
+                      >
+                        <UInput
+                          v-model="ni.nameIdentifierScheme"
+                          placeholder="e.g., ORCID"
+                        />
+                      </UFormField>
+
+                      <UFormField
+                        class="w-full"
+                        :name="`creators.${cIndex}.nameIdentifiers.${niIndex}.nameIdentifier`"
+                        label="Identifier"
+                        required
+                      >
+                        <UInput
+                          v-model="ni.nameIdentifier"
+                          placeholder="https://orcid.org/0000-0000-0000-0000"
+                          @update:model-value="
+                            (v) => handleNameIdentifierInput(v, cIndex, niIndex)
+                          "
+                        />
+                      </UFormField>
+
+                      <UButton
+                        class="mt-6"
+                        size="sm"
+                        color="error"
+                        variant="outline"
+                        icon="i-lucide-trash"
+                        @click="
+                          removeRow(
+                            state.creators[cIndex]?.nameIdentifiers!,
+                            niIndex,
+                          )
+                        "
+                      />
+
+                      <UButton
+                        class="mt-6"
+                        size="sm"
+                        color="success"
+                        variant="outline"
+                        icon="i-lucide-plus"
+                        @click="
+                          state.creators[cIndex]?.nameIdentifiers?.push({
+                            nameIdentifier: '',
+                            nameIdentifierScheme: '',
+                            schemeURI: '',
+                          })
+                        "
+                      />
+                    </div>
+
+                    <UFormField
+                      :name="`creators.${cIndex}.nameIdentifiers.${niIndex}.schemeURI`"
+                      label="Scheme URI"
+                    >
+                      <UInput
+                        v-model="ni.schemeURI"
+                        placeholder="https://orcid.org"
+                        class="w-full"
+                      />
+                    </UFormField>
+                  </div>
+                </div>
+
+                <div v-else>
+                  <UButton
+                    size="sm"
+                    class="w-full"
+                    color="success"
+                    variant="outline"
+                    label="Add Creator Identifier"
+                    icon="i-lucide-plus"
+                    @click="
+                      state.creators[cIndex]?.nameIdentifiers?.push({
+                        nameIdentifier: '',
+                        nameIdentifierScheme: '',
+                        schemeURI: '',
+                      })
+                    "
+                  />
+                </div>
+              </UFormField>
 
               <UFormField label="Affiliations" name="affiliation">
                 <div
@@ -790,6 +947,14 @@ async function addSubjectAndFocus() {
                         <UInput
                           v-model="affiliation.affiliationIdentifier"
                           placeholder="https://ror.org/0168r3w48"
+                          @update:model-value="
+                            (v) =>
+                              handleAffiliationIdentifierInput(
+                                v,
+                                cIndex,
+                                aIndex,
+                              )
+                          "
                         />
                       </UFormField>
 
@@ -830,93 +995,6 @@ async function addSubjectAndFocus() {
                         name: '',
                         affiliationIdentifier: '',
                         affiliationIdentifierScheme: '',
-                        schemeURI: '',
-                      })
-                    "
-                  />
-                </div>
-              </UFormField>
-
-              <UFormField
-                label="Creator Identifiers (e.g., ORCID)"
-                name="nameIdentifiers"
-              >
-                <div
-                  v-if="
-                    state.creators[cIndex]?.nameIdentifiers &&
-                    state.creators[cIndex]?.nameIdentifiers?.length > 0
-                  "
-                >
-                  <div
-                    v-for="(ni, niIndex) in state.creators[cIndex]
-                      ?.nameIdentifiers"
-                    :key="niIndex"
-                    class="mb-2 flex gap-2"
-                  >
-                    <UFormField
-                      class="w-40 shrink-0"
-                      :name="`creators.${cIndex}.nameIdentifiers.${niIndex}.nameIdentifierScheme`"
-                      label="Identifier Type"
-                    >
-                      <UInput
-                        v-model="ni.nameIdentifierScheme"
-                        placeholder="e.g., ORCID"
-                      />
-                    </UFormField>
-
-                    <UFormField
-                      class="w-full"
-                      :name="`creators.${cIndex}.nameIdentifiers.${niIndex}.nameIdentifier`"
-                      label="Identifier"
-                      required
-                    >
-                      <UInput
-                        v-model="ni.nameIdentifier"
-                        placeholder="https://orcid.org/0000-0000-0000-0000"
-                      />
-                    </UFormField>
-
-                    <UButton
-                      size="sm"
-                      color="error"
-                      variant="outline"
-                      icon="i-lucide-trash"
-                      @click="
-                        removeRow(
-                          state.creators[cIndex]?.nameIdentifiers!,
-                          niIndex,
-                        )
-                      "
-                    />
-
-                    <UButton
-                      size="sm"
-                      color="success"
-                      variant="outline"
-                      icon="i-lucide-plus"
-                      @click="
-                        state.creators[cIndex]?.nameIdentifiers?.push({
-                          nameIdentifier: '',
-                          nameIdentifierScheme: '',
-                          schemeURI: '',
-                        })
-                      "
-                    />
-                  </div>
-                </div>
-
-                <div v-else>
-                  <UButton
-                    size="sm"
-                    class="w-full"
-                    color="success"
-                    variant="outline"
-                    label="Add Creator Identifier"
-                    icon="i-lucide-plus"
-                    @click="
-                      state.creators[cIndex]?.nameIdentifiers?.push({
-                        nameIdentifier: '',
-                        nameIdentifierScheme: '',
                         schemeURI: '',
                       })
                     "
@@ -1079,15 +1157,15 @@ async function addSubjectAndFocus() {
       >
         <div class="space-y-6">
           <CardCollapsibleContent
-            title="Submission Abstract"
+            title="Poster Abstract"
             :collapse="false"
-            description="A formal abstract for conference or repository submission."
+            description="Provide here your poster abstract exactly as submitted to the conference."
           >
             <UFormField name="submissionAbstract">
               <UTextarea
                 v-model="state.submissionAbstract"
                 class="w-full"
-                placeholder="Enter a formal abstract for submission purposes"
+                placeholder="Enter your poster abstract as submitted to the conference"
               />
             </UFormField>
           </CardCollapsibleContent>
@@ -1457,7 +1535,6 @@ async function addSubjectAndFocus() {
                 <UFormField
                   :name="`posterContent.sections.${sIndex}.sectionTitle`"
                   label="Section Title"
-                  required
                   class="flex-1"
                 >
                   <UInput
@@ -1469,7 +1546,6 @@ async function addSubjectAndFocus() {
                 <UFormField
                   :name="`posterContent.sections.${sIndex}.sectionContent`"
                   label="Section Content"
-                  required
                   class="flex-1"
                 >
                   <!-- TODO: Add a rich text editor here. -->

--- a/app/pages/zenodo-auth-error.vue
+++ b/app/pages/zenodo-auth-error.vue
@@ -3,7 +3,7 @@ const route = useRoute();
 const posterId = route.query.posterId as string | undefined;
 
 const reviewLink = posterId
-  ? `/share/${posterId}/review?repository=zenodo`
+  ? `/share/${posterId}/publish?repository=zenodo`
   : "/dashboard";
 </script>
 

--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -213,9 +213,12 @@ export async function beginZenodoPublication(
   const bucketUrl = deposition.links.bucket;
   const { doi } = deposition.metadata.prereserve_doi;
 
+  const draftUrl = `${config.zenodoEndpoint}/deposit/${newDepositionId}`;
+
   console.log(
     `[Zenodo] Working deposition ready - id: ${newDepositionId}, doi: ${doi}, bucket: ${bucketUrl}`,
   );
+  console.log(`[Zenodo] Draft URL: ${draftUrl}`);
 
   // Update zenodoDeposition information
   const posterInt = parseInt(posterId);
@@ -341,15 +344,42 @@ export async function beginZenodoPublication(
     awardNumber?: string;
   }[];
 
-  const zenodoGrants = Array.isArray(rawFunding)
-    ? rawFunding
-        .filter((f) => f.funderIdentifier)
-        .map((f) => ({
-          id: f.awardNumber
-            ? `${f.funderIdentifier}::${f.awardNumber}`
-            : f.funderIdentifier!,
-        }))
+  // Entries without an award number are skipped since it is not valid for Zenodo
+  // Each candidate is validated against Zenodo's awards API, which is the
+  // only reliable way to know if Zenodo will accept it. If found, we use Zenodo's
+  // canonical award ID directly so the format is always correct regardless of what
+  // identifier type the user entered. The retry fallback below handles edge cases.
+  const candidateGrants = Array.isArray(rawFunding)
+    ? rawFunding.filter((f) => f.awardNumber?.trim())
     : [];
+
+  const zenodoGrants: { id: string }[] = [];
+
+  for (const grant of candidateGrants) {
+    const awardNumber = grant.awardNumber!.trim();
+
+    const awardsRes = await fetch(
+      `${config.zenodoApiEndpoint}/awards?q=${encodeURIComponent(awardNumber)}&size=5`,
+    ).catch(() => null);
+
+    const awardsData = awardsRes?.ok
+      ? await awardsRes.json().catch(() => null)
+      : null;
+    const match = awardsData?.hits?.hits?.find(
+      (a: { id: string; number: string }) => a.number === awardNumber,
+    );
+
+    if (match) {
+      console.log(
+        `[Zenodo] Grant validated: "${match.id}" (${match.funder?.name})`,
+      );
+      zenodoGrants.push({ id: match.id });
+    } else {
+      console.log(
+        `[Zenodo] Skipping grant with award "${awardNumber}" - not found in Zenodo's awards database`,
+      );
+    }
+  }
 
   const conferenceDates =
     meta.conferenceStartDate && meta.conferenceEndDate
@@ -403,12 +433,40 @@ export async function beginZenodoPublication(
 
   // Update the zenodo deposition metadata
   console.log(`[Zenodo] Updating metadata for deposition: ${newDepositionId}`);
+  console.log(`[Zenodo] Grants being sent: ${JSON.stringify(zenodoGrants)}`);
 
-  await updateDepositionMetadata(
+  let metadataResult = await updateDepositionMetadata(
     newDepositionId,
     tokenRecord.accessToken,
     metadata,
   );
+
+  // Zenodo validates grant IDs against its internal OpenAIRE database and rejects the
+  // entire metadata PUT if any grant is unrecognised. Retry without grants so publication
+  // still gets added
+  if (
+    !metadataResult.success &&
+    metadataResult.error?.includes("Invalid value") &&
+    zenodoGrants.length > 0
+  ) {
+    console.log(
+      `[Zenodo] One or more grants not found in Zenodo's OpenAIRE database, retrying without grants. Dropped: ${JSON.stringify(zenodoGrants)}`,
+    );
+
+    const metadataWithoutGrants = {
+      metadata: { ...metadata.metadata, grants: undefined },
+    };
+
+    metadataResult = await updateDepositionMetadata(
+      newDepositionId,
+      tokenRecord.accessToken,
+      metadataWithoutGrants,
+    );
+  }
+
+  if (!metadataResult.success) {
+    return { success: false, error: metadataResult.error };
+  }
 
   await onProgress?.({
     step: "upload_metadata",
@@ -535,7 +593,8 @@ export async function beginZenodoPublication(
   });
 
   // Publish the deposition
-  console.log(`[Zenodo] Publishing deposition: ${newDepositionId}`);
+  console.log(`[Zenodo] About to publish deposition: ${newDepositionId}`);
+  console.log(`[Zenodo] Inspect draft before publish: ${draftUrl}`);
 
   const publishResult = await publishZenodoDeposition(
     tokenRecord.accessToken,
@@ -858,30 +917,6 @@ async function updateDepositionMetadata(
 
     console.log(`[Zenodo] Metadata updated for deposition: ${depositionId}`);
 
-    // if the metadata does not have an upload_type, add it and update the metadata again
-    console.log("[Zenodo] Checking for upload_type in metadata");
-    if (
-      !updatedData?.metadata?.upload_type ||
-      updatedData?.metadata?.upload_type != "poster"
-    ) {
-      console.log(
-        "[Zenodo] upload_type present, re-updating metadata with poster type",
-      );
-
-      console.log("[Zenodo] Current metadata:", updatedData.metadata);
-
-      const newMetadata = {
-        ...updatedData.metadata,
-        upload_type: "poster",
-      };
-
-      console.log("[Zenodo] New metadata:", newMetadata);
-
-      await updateDepositionMetadata(depositionId, zenodoToken, {
-        metadata: newMetadata,
-      });
-    }
-
     return { success: true, data: updatedData };
   } catch (error) {
     console.log("[Zenodo] Error updating metadata:", error);
@@ -1111,6 +1146,9 @@ async function publishZenodoDeposition(
 
     console.log(
       `[Zenodo] Deposition ${depositionId} published at: ${data.links?.latest_html}`,
+    );
+    console.log(
+      `[Zenodo] Published record URL: ${data.links?.record_html ?? data.links?.latest_html}`,
     );
 
     return { success: true, data };

--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -366,7 +366,8 @@ export async function beginZenodoPublication(
       ? await awardsRes.json().catch(() => null)
       : null;
     const match = awardsData?.hits?.hits?.find(
-      (a: { id: string; number: string }) => a.number === awardNumber,
+      (a: { id: string; number: string; funder?: { name?: string } }) =>
+        a.number === awardNumber,
     );
 
     if (match) {

--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -334,6 +334,23 @@ export async function beginZenodoPublication(
         }))
     : [];
 
+  const rawFunding = meta.fundingReferences as {
+    funderName?: string;
+    funderIdentifier?: string;
+    funderIdentifierType?: string;
+    awardNumber?: string;
+  }[];
+
+  const zenodoGrants = Array.isArray(rawFunding)
+    ? rawFunding
+        .filter((f) => f.funderIdentifier)
+        .map((f) => ({
+          id: f.awardNumber
+            ? `${f.funderIdentifier}::${f.awardNumber}`
+            : f.funderIdentifier!,
+        }))
+    : [];
+
   const conferenceDates =
     meta.conferenceStartDate && meta.conferenceEndDate
       ? `${meta.conferenceStartDate} - ${meta.conferenceEndDate}`
@@ -380,6 +397,7 @@ export async function beginZenodoPublication(
       ...(meta.publicationYear && {
         publication_date: `${meta.publicationYear}`,
       }),
+      ...(zenodoGrants.length > 0 && { grants: zenodoGrants }),
     },
   };
 


### PR DESCRIPTION
## Summary by Sourcery

Enhance Zenodo metadata handling for shared posters, including richer author labelling, identifier auto-detection, and robust funding/grant integration.

New Features:
- Display per-author labels in the share UI and allow editing of creator identifiers with scheme URIs, including ORCID, with improved layout.
- Auto-detect ORCID and ROR identifiers from user input and back-fill the corresponding identifier schemes and scheme URIs for creators and affiliations.
- Include funding information in Zenodo metadata by validating grant award numbers against Zenodo's awards API and attaching recognised grants to the deposition.

Enhancements:
- Improve Zenodo publication logging with draft and published record URLs and clearer messages around publishing steps.
- Relax required constraints on poster section title and content fields to make poster content entry more flexible.
- Remove redundant post-update enforcement of the Zenodo upload_type metadata, relying on earlier metadata construction instead.