### PR TITLE
feat: ✨ Zenodo metadata adjustments

### DIFF
--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -152,6 +152,25 @@ type ProgressCallback = (
   event: PublicationProgressEvent,
 ) => void | Promise<void>;
 
+function extractOrcid(ni: {
+  nameIdentifier: string;
+  nameIdentifierScheme?: string;
+  schemeURI?: string;
+}): string | undefined {
+  const { nameIdentifier, nameIdentifierScheme, schemeURI } = ni;
+  if (!nameIdentifier) return undefined;
+
+  if (nameIdentifier.toLowerCase().includes("orcid.org/")) {
+    return nameIdentifier.replace(/.*orcid\.org\//i, "").trim() || undefined;
+  }
+
+  const isOrcid =
+    nameIdentifierScheme?.toLowerCase() === "orcid" ||
+    schemeURI?.toLowerCase().includes("orcid.org");
+
+  return isOrcid ? nameIdentifier : undefined;
+}
+
 export async function beginZenodoPublication(
   posterId: string,
   mode: string,
@@ -310,7 +329,8 @@ export async function beginZenodoPublication(
     affiliation?: { name: string }[];
     nameIdentifiers?: {
       nameIdentifier: string;
-      nameIdentifierScheme: string;
+      nameIdentifierScheme?: string;
+      schemeURI?: string;
     }[];
   }[];
 
@@ -393,9 +413,7 @@ export async function beginZenodoPublication(
       upload_type: "poster",
       publication_type: "poster",
       creators: creators.map((c) => {
-        const orcid = c.nameIdentifiers?.find(
-          (n) => n.nameIdentifierScheme?.toLowerCase() === "orcid",
-        )?.nameIdentifier;
+        const orcid = c.nameIdentifiers?.map(extractOrcid).find(Boolean);
 
         return {
           name: c.name,

--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -715,11 +715,26 @@ export async function beginZenodoPublication(
     },
   });
 
+  const publishedDoi = publishResult.data.doi;
+  const currentIdentifiers = Array.isArray(meta.identifiers)
+    ? (meta.identifiers as { identifier: string; identifierType: string }[])
+    : [];
+  const alreadyHasDoi = currentIdentifiers.some(
+    (i) => i.identifier === publishedDoi && i.identifierType === "DOI",
+  );
+  const updatedIdentifiers = alreadyHasDoi
+    ? currentIdentifiers
+    : [
+        { identifier: publishedDoi, identifierType: "DOI" },
+        ...currentIdentifiers,
+      ];
+
   await prisma.posterMetadata.update({
     where: { posterId: posterInt },
     data: {
-      doi: publishResult.data.doi,
+      doi: publishedDoi,
       publisher: "Zenodo",
+      identifiers: updatedIdentifiers,
     },
   });
 

--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -469,6 +469,11 @@ export async function beginZenodoPublication(
     return { success: false, error: metadataResult.error };
   }
 
+  const zenodoVersion = metadataResult.data?.metadata?.version;
+  if (zenodoVersion) {
+    meta.version = zenodoVersion;
+  }
+
   await onProgress?.({
     step: "upload_metadata",
     status: "completed",
@@ -729,12 +734,15 @@ export async function beginZenodoPublication(
         ...currentIdentifiers,
       ];
 
+  const publishedVersion = publishResult.data.metadata?.version || undefined;
+
   await prisma.posterMetadata.update({
     where: { posterId: posterInt },
     data: {
       doi: publishedDoi,
       publisher: "Zenodo",
       identifiers: updatedIdentifiers,
+      ...(publishedVersion && { version: publishedVersion }),
     },
   });
 

--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -490,6 +490,13 @@ export async function beginZenodoPublication(
   const zenodoVersion = metadataResult.data?.metadata?.version;
   if (zenodoVersion) {
     meta.version = zenodoVersion;
+  } else if (!meta.version) {
+    meta.version = mode === "new" ? "1" : undefined;
+  } else if (mode === "existing") {
+    const prev = parseInt(meta.version, 10);
+    if (!isNaN(prev)) {
+      meta.version = String(prev + 1);
+    }
   }
 
   await onProgress?.({
@@ -752,15 +759,13 @@ export async function beginZenodoPublication(
         ...currentIdentifiers,
       ];
 
-  const publishedVersion = publishResult.data.metadata?.version || undefined;
-
   await prisma.posterMetadata.update({
     where: { posterId: posterInt },
     data: {
       doi: publishedDoi,
       publisher: "Zenodo",
       identifiers: updatedIdentifiers,
-      ...(publishedVersion && { version: publishedVersion }),
+      ...(meta.version && { version: meta.version }),
     },
   });
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust Zenodo publication metadata handling for ORCID extraction, versioning, and DOI identifiers.

New Features:
- Derive and persist poster version metadata from Zenodo responses, with sensible defaults and increments for new and existing publications.
- Store published DOIs in a structured identifiers array alongside the primary DOI field when saving poster metadata.

Enhancements:
- Improve ORCID detection by extracting ORCID IDs from various name identifier formats, including scheme URIs, while allowing optional identifier scheme fields.