### PR TITLE
feat: ✨ Auto indexed badges + zenodo Orcid normalization

### DIFF
--- a/app/pages/discover/index.vue
+++ b/app/pages/discover/index.vue
@@ -44,6 +44,7 @@ type Poster = {
   updated: Date;
   // views: number;
   likes: number;
+  automated: boolean;
 };
 
 const PAGE_SIZE = 9;
@@ -70,6 +71,8 @@ const mapPosters = (apiPosters: Poster[]) => {
     updated: poster.updated ? poster.updated : new Date(),
     // views: typeof poster.views === "number" ? poster.views : 0,
     likes: typeof poster.likes === "number" ? poster.likes : 0,
+    automated:
+      typeof poster.automated === "boolean" ? poster.automated : false,
   }));
 };
 
@@ -233,6 +236,16 @@ const hasActiveFilters = computed(() => !!dateFilterValue.value.start);
                       :alt="poster.title"
                       class="h-48 w-full object-cover transition-transform duration-300 group-hover:scale-105"
                     />
+
+                    <UBadge
+                      v-if="poster.automated"
+                      color="primary"
+                      variant="solid"
+                      icon="i-lucide-sparkles"
+                      class="absolute left-2 top-2 z-10"
+                    >
+                      Auto-indexed
+                    </UBadge>
                   </div>
 
                   <div class="relative flex flex-col justify-between gap-2 p-2">

--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -152,6 +152,8 @@ type ProgressCallback = (
   event: PublicationProgressEvent,
 ) => void | Promise<void>;
 
+type PosterIdentifier = { identifier: string; identifierType: string };
+
 function extractOrcid(ni: {
   nameIdentifier: string;
   nameIdentifierScheme?: string;
@@ -323,6 +325,10 @@ export async function beginZenodoPublication(
 
   // Build Zenodo deposition metadata from poster data
   const meta = poster.posterMetadata;
+
+  const metaIdentifiers: PosterIdentifier[] = Array.isArray(meta.identifiers)
+    ? (meta.identifiers as PosterIdentifier[])
+    : [];
 
   const creators = meta.creators as {
     name: string;
@@ -746,18 +752,21 @@ export async function beginZenodoPublication(
   });
 
   const publishedDoi = publishResult.data.doi;
-  const currentIdentifiers = Array.isArray(meta.identifiers)
-    ? (meta.identifiers as { identifier: string; identifierType: string }[])
-    : [];
-  const alreadyHasDoi = currentIdentifiers.some(
+
+  if (!publishedDoi) {
+    console.error(
+      `[Zenodo] Published deposition ${newDepositionId} is missing a DOI in the response`,
+    );
+
+    return { success: false, error: "Published deposition is missing a DOI" };
+  }
+
+  const alreadyHasDoi = metaIdentifiers.some(
     (i) => i.identifier === publishedDoi && i.identifierType === "DOI",
   );
-  const updatedIdentifiers = alreadyHasDoi
-    ? currentIdentifiers
-    : [
-        { identifier: publishedDoi, identifierType: "DOI" },
-        ...currentIdentifiers,
-      ];
+  const updatedIdentifiers: PosterIdentifier[] = alreadyHasDoi
+    ? metaIdentifiers
+    : [{ identifier: publishedDoi, identifierType: "DOI" }, ...metaIdentifiers];
 
   await prisma.posterMetadata.update({
     where: { posterId: posterInt },


### PR DESCRIPTION
## Summary by Sourcery

Handle missing DOIs from Zenodo publications and surface auto-indexed posters in the discover page.

New Features:
- Display an "Auto-indexed" badge on discover cards for posters that were automatically indexed.

Bug Fixes:
- Prevent failures when a published Zenodo deposition response lacks a DOI by validating the response and returning a clear error.

Enhancements:
- Normalize and reuse poster metadata identifiers when attaching the published DOI to poster records.
- Add an `automated` flag to posters returned to the frontend and map it safely with a default value.