### PR TITLE
feat: ✨ ORCID API validation

### DIFF
--- a/app/pages/share/[id]/index.vue
+++ b/app/pages/share/[id]/index.vue
@@ -942,7 +942,7 @@ async function addSubjectAndFocus() {
                       v-for="(ni, niIndex) in state.creators[cIndex]
                         ?.nameIdentifiers"
                       :key="niIndex"
-                      class="mb-2 space-y-2 rounded-xl border border-l-4 border-gray-200 border-l-pink-300 p-3 dark:border-l-pink-700"
+                      class="mb-2 space-y-2 rounded-r-xl border border-l-4 border-gray-200 border-l-pink-300 p-3 dark:border-l-pink-700"
                     >
                       <div class="flex gap-2">
                         <UFormField
@@ -1054,7 +1054,7 @@ async function addSubjectAndFocus() {
                       v-for="(affiliation, aIndex) in state.creators[cIndex]
                         ?.affiliation"
                       :key="aIndex"
-                      class="mb-2 space-y-2 rounded-xl border border-l-4 border-gray-200 border-l-pink-300 p-3 dark:border-l-pink-700"
+                      class="mb-2 space-y-2 rounded-r-xl border border-l-4 border-gray-200 border-l-pink-300 p-3 dark:border-l-pink-700"
                     >
                       <div class="flex gap-2">
                         <UFormField
@@ -1480,7 +1480,7 @@ async function addSubjectAndFocus() {
                     relatedIdentifier, iIndex
                   ) in state.relatedIdentifiers"
                   :key="iIndex"
-                  class="space-y-2 rounded-xl border border-l-4 border-gray-200 border-l-pink-300 p-4 dark:border-l-pink-700"
+                  class="space-y-2 rounded-r-xl border border-l-4 border-gray-200 border-l-pink-300 p-4 dark:border-l-pink-700"
                 >
                   <div class="flex items-start gap-3">
                     <UFormField

--- a/app/pages/share/[id]/index.vue
+++ b/app/pages/share/[id]/index.vue
@@ -18,6 +18,8 @@ import {
   normalizeNameIdentifierToUrl,
   normalizeAffiliationIdentifierToUrl,
   schemeUriForScheme,
+  extractOrcidId,
+  validateOrcidExists,
 } from "@/utils/poster_schema";
 import {
   type CalendarDate,
@@ -47,6 +49,8 @@ useSeoMeta({
 });
 
 const loading = ref(false);
+const orcidErrors = ref<Record<string, string | undefined>>({});
+const orcidChecking = ref<Record<string, boolean | undefined>>({});
 const additionalInfoCollapsed = ref(true);
 const posterContentCollapsed = ref(true);
 const mandatoryCollapsed = ref(false);
@@ -526,6 +530,18 @@ async function saveDraft() {
 }
 
 async function onSubmit(event: FormSubmitEvent<StrictFormSchema>) {
+  if (Object.values(orcidErrors.value).some(Boolean)) {
+    toast.add({
+      title: "ORCID Validation Error",
+      description:
+        "One or more creator ORCIDs could not be found. Verify or remove them before saving.",
+      color: "error",
+      icon: "material-symbols:error",
+    });
+
+    return;
+  }
+
   console.log("Submitting poster metadata");
   loading.value = true;
 
@@ -642,6 +658,7 @@ function handleNameIdentifierInput(
   cIndex: number,
   niIndex: number,
 ) {
+  orcidErrors.value[`${cIndex}-${niIndex}`] = undefined;
   const ni = state.creators[cIndex]?.nameIdentifiers?.[niIndex];
   if (!ni) return;
   const inferred = inferNameIdentifierScheme(value);
@@ -652,6 +669,31 @@ function handleNameIdentifierInput(
       const normalized = normalizeNameIdentifierToUrl(value, inferred.scheme);
       if (normalized) ni.nameIdentifier = normalized;
     }
+  }
+}
+
+async function handleOrcidBlur(cIndex: number, niIndex: number) {
+  const ni = state.creators[cIndex]?.nameIdentifiers?.[niIndex];
+  if (!ni?.nameIdentifier) return;
+
+  const isOrcid =
+    ni.nameIdentifierScheme?.toLowerCase() === "orcid" ||
+    ni.nameIdentifier.toLowerCase().includes("orcid.org");
+  if (!isOrcid) return;
+
+  const orcidId = extractOrcidId(ni.nameIdentifier);
+  if (!orcidId) return;
+
+  const key = `${cIndex}-${niIndex}`;
+  orcidErrors.value[key] = undefined;
+  orcidChecking.value[key] = true;
+
+  const exists = await validateOrcidExists(orcidId);
+  orcidChecking.value[key] = false;
+
+  if (!exists) {
+    orcidErrors.value[key] =
+      "ORCID not found. Verify the ID at orcid.org or remove it.";
   }
 }
 
@@ -969,14 +1011,17 @@ async function addSubjectAndFocus() {
                           :name="`creators.${cIndex}.nameIdentifiers.${niIndex}.nameIdentifier`"
                           label="Identifier"
                           required
+                          :error="orcidErrors[`${cIndex}-${niIndex}`]"
                         >
                           <UInput
                             v-model="ni.nameIdentifier"
                             placeholder="https://orcid.org/0000-0000-0000-0000"
+                            :loading="orcidChecking[`${cIndex}-${niIndex}`]"
                             @update:model-value="
                               (v) =>
                                 handleNameIdentifierInput(v, cIndex, niIndex)
                             "
+                            @blur="() => handleOrcidBlur(cIndex, niIndex)"
                           />
                         </UFormField>
 

--- a/app/utils/poster_schema.ts
+++ b/app/utils/poster_schema.ts
@@ -239,6 +239,27 @@ export function normalizeAffiliationIdentifierToUrl(
   }
 }
 
+// Extracts the bare ORCID ID (XXXX-XXXX-XXXX-XXXX) from a full URL or bare value.
+export function extractOrcidId(value: string): string | null {
+  const match = value.match(/(\d{4}-\d{4}-\d{4}-\d{3}[\dX])/i);
+
+  return match?.[1] ?? null;
+}
+
+// Checks whether an ORCID ID actually exists in the ORCID registry.
+// Returns true on network failure so users are never blocked by connectivity issues.
+export async function validateOrcidExists(orcidId: string): Promise<boolean> {
+  try {
+    const res = await fetch(`https://pub.orcid.org/v3.0/${orcidId}`, {
+      headers: { Accept: "application/json" },
+    });
+
+    return res.ok;
+  } catch {
+    return true;
+  }
+}
+
 // Constants and options for select fields
 const DATE_TYPE_VALUES = [
   "Accepted",

--- a/server/utils/buildPosterJson.ts
+++ b/server/utils/buildPosterJson.ts
@@ -134,7 +134,7 @@ export function buildPosterJson(
           {
             date: formatDateISO(options.publishedAt),
             dateType: "Submitted",
-            dateInformation: "Submitted to Zenodo through posters.science",
+            dateInformation: "Submitted to Zenodo through Posters.science",
           },
           ...existingDates,
         ]

--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -384,7 +384,7 @@ export async function beginZenodoPublication(
     zenodoDates.push({
       date: zenodoSharedAt.toISOString().slice(0, 10),
       type: { id: "submitted" },
-      description: "Submitted to Zenodo through posters.science",
+      description: "Submitted to Zenodo through Posters.science",
     });
   }
 


### PR DESCRIPTION
## Summary by Sourcery

Add ORCID identifier validation against the ORCID API when editing and submitting poster metadata, and make minor copy and styling tweaks.

New Features:
- Validate creator ORCID identifiers against the ORCID public API on blur in the share poster form, showing inline field errors and preventing submission when invalid.

Enhancements:
- Extract and reuse ORCID IDs from user input via a utility helper.
- Adjust border rounding on creator name identifier, affiliation, and related identifier cards for consistent UI styling.
- Update Zenodo submission metadata text to use the correct Posters.science branding.