### PR TITLE
feat: :sparkles: QOL update to date picker

### DIFF
--- a/app/components/discover/PublishedDateFilter.vue
+++ b/app/components/discover/PublishedDateFilter.vue
@@ -18,6 +18,7 @@ const props = defineProps<{
 
     <DateRangePicker
       v-model="modelValue"
+      label="Published"
       :number-of-months="props.numberOfMonths ?? 2"
       clearable
     />

--- a/app/components/ui/DateRangePicker.vue
+++ b/app/components/ui/DateRangePicker.vue
@@ -18,6 +18,7 @@ const props = defineProps<{
   variant?: string;
   placeholder?: string;
   clearable?: boolean;
+  label?: string;
 }>();
 
 const df = new DateFormatter("en-US", { dateStyle: "medium" });
@@ -39,6 +40,33 @@ watch(
 );
 
 const isOpen = ref(false);
+const toast = useToast();
+let closedViaConfirm = false;
+
+function rangesMatch() {
+  return (
+    localRange.value.start?.toString() === modelValue.value.start?.toString() &&
+    localRange.value.end?.toString() === modelValue.value.end?.toString()
+  );
+}
+
+watch(isOpen, (open) => {
+  if (!open) {
+    if (!closedViaConfirm && localRange.value.start && !rangesMatch()) {
+      const fieldLabel = props.label ?? "Date range";
+      toast.add({
+        title: `${fieldLabel} not saved`,
+        description: "Click Confirm to apply your selection.",
+        color: "warning",
+      });
+      localRange.value = {
+        start: modelValue.value.start,
+        end: modelValue.value.end,
+      };
+    }
+    closedViaConfirm = false;
+  }
+});
 
 function onCalendarChange(value: {
   start: CalendarDate | undefined;
@@ -48,6 +76,7 @@ function onCalendarChange(value: {
 }
 
 function confirm() {
+  closedViaConfirm = true;
   const { start, end } = localRange.value;
   if (!start) return;
   modelValue.value = { start, end: end ?? start };

--- a/app/pages/share/[id]/index.vue
+++ b/app/pages/share/[id]/index.vue
@@ -1304,6 +1304,7 @@ async function addSubjectAndFocus() {
                 >
                   <DateRangePicker
                     v-model="conferenceDateRange"
+                    label="Conference dates"
                     variant="subtle"
                     placeholder="Pick a date range"
                     clearable


### PR DESCRIPTION
## Summary by Sourcery

Add a labeled date range picker behavior that warns users when closing without confirming changes and integrate labels for specific usages.

New Features:
- Introduce a toast warning when a date range selection is closed without confirmation to prevent accidental loss of changes.
- Allow the date range picker to accept an optional label used in user-facing messaging.
- Set descriptive labels for published date and conference date range pickers where the component is used.