### PR TITLE
Fix scholarlyarticle schema

### DIFF
--- a/app/pages/discover/[posterid]/index.vue
+++ b/app/pages/discover/[posterid]/index.vue
@@ -36,10 +36,12 @@ const conf = api?.conference;
 const liked = ref(api?.liked ?? false);
 
 const liking = ref(false);
-
 const poster = ref({
   id: api?.id ?? posterId,
   automated: api?.automated ?? false,
+  citations: (api?.relatedIdentifiers ?? []).filter(
+    (ri: any) => ri.relationType === "Cites",
+  ),
   title: api?.title ?? "Untitled Poster",
   description: api?.description ?? "",
   imageUrl:
@@ -249,9 +251,9 @@ const NuxtSchemaPoster: WithContext<ScholarlyArticle> = {
         sameAs: author.orcid || undefined,
       }))
     : undefined,
-  citation: poster.value.references
-    ?.map((r: any) => r.doi || r.url || r.title)
-    .filter(Boolean),
+  citation: poster.value?.citations?.length
+    ? poster.value.citations.map((citation: any) => citation.relatedIdentifier)
+    : undefined,
   datePublished: poster.value?.publishedAt?.toISOString() || undefined,
   description: poster.value?.description || undefined,
   funder: poster.value.funding?.length
@@ -297,8 +299,7 @@ console.log(
   "cleanSchema(NuxtSchemaPoster):",
   JSON.stringify(cleanSchema(NuxtSchemaPoster), null, 2),
 );
-console.log("doi", poster.value.doi);
-console.log("citations", NuxtSchemaPoster.citation);
+
 useSchemaOrg([cleanSchema(NuxtSchemaPoster)]);
 
 const handleLike = async () => {

--- a/app/pages/discover/[posterid]/index.vue
+++ b/app/pages/discover/[posterid]/index.vue
@@ -74,6 +74,7 @@ const poster = ref({
   }),
   publishedAt: api?.publishedAt ? new Date(api.publishedAt) : undefined,
   version: api?.version ?? null,
+  submissionAbstract: api?.submissionAbstract ?? null,
   doi: api?.doi ?? null,
   license: api?.license ?? null,
   publisher: api?.publisher ?? null,
@@ -226,6 +227,10 @@ const cleanSchema = (value: any): any => {
   return value;
 };
 
+const citationIdentifiers = poster.value?.citations?.length
+  ? poster.value.citations.map((citation: any) => citation.relatedIdentifier)
+  : undefined;
+
 const NuxtSchemaPoster: WithContext<ScholarlyArticle> = {
   "@context": "https://schema.org",
   "@id": resolvedPosterUrl.value || undefined,
@@ -236,7 +241,7 @@ const NuxtSchemaPoster: WithContext<ScholarlyArticle> = {
         name: poster.value.domain,
       }
     : undefined,
-  abstract: poster.value?.description || undefined,
+  abstract: poster.value?.submissionAbstract || undefined,
   author: poster.value?.authors?.length
     ? poster.value.authors.map((author: any) => ({
         "@type": "Person",
@@ -251,9 +256,7 @@ const NuxtSchemaPoster: WithContext<ScholarlyArticle> = {
         sameAs: author.orcid || undefined,
       }))
     : undefined,
-  citation: poster.value?.citations?.length
-    ? poster.value.citations.map((citation: any) => citation.relatedIdentifier)
-    : undefined,
+  citation: citationIdentifiers,
   datePublished: poster.value?.publishedAt?.toISOString() || undefined,
   description: poster.value?.description || undefined,
   funder: poster.value.funding?.length
@@ -295,10 +298,6 @@ const NuxtSchemaPoster: WithContext<ScholarlyArticle> = {
   url: discoverUrl.value || undefined,
   version: poster.value?.version || undefined,
 };
-console.log(
-  "cleanSchema(NuxtSchemaPoster):",
-  JSON.stringify(cleanSchema(NuxtSchemaPoster), null, 2),
-);
 
 useSchemaOrg([cleanSchema(NuxtSchemaPoster)]);
 

--- a/app/pages/discover/[posterid]/index.vue
+++ b/app/pages/discover/[posterid]/index.vue
@@ -284,7 +284,7 @@ const NuxtSchemaPoster: WithContext<ScholarlyArticle> = {
     },
   ],
   keywords: poster.value?.keywords?.length ? poster.value.keywords : undefined,
-  license: poster.value?.license || undefined,
+  license: licenseInfo.value?.reference || undefined,
   publisher: poster.value?.publisher
     ? { "@type": "Organization", name: poster.value.publisher }
     : undefined,
@@ -293,7 +293,12 @@ const NuxtSchemaPoster: WithContext<ScholarlyArticle> = {
   url: discoverUrl.value || undefined,
   version: poster.value?.version || undefined,
 };
-
+console.log(
+  "cleanSchema(NuxtSchemaPoster):",
+  JSON.stringify(cleanSchema(NuxtSchemaPoster), null, 2),
+);
+console.log("doi", poster.value.doi);
+console.log("citations", NuxtSchemaPoster.citation);
 useSchemaOrg([cleanSchema(NuxtSchemaPoster)]);
 
 const handleLike = async () => {

--- a/server/api/discover/[posterid]/index.get.ts
+++ b/server/api/discover/[posterid]/index.get.ts
@@ -86,6 +86,8 @@ export default defineEventHandler(async (event) => {
     creators: (meta?.creators as any[]) ?? [],
     fundingReferences: (meta?.fundingReferences as any[]) ?? [],
     relatedIdentifiers: (meta?.relatedIdentifiers as any[]) ?? [],
+    submissionAbstract:
+      (meta?.posterContent as any)?.submissionAbstract ?? null,
     conference: {
       conferenceName: meta?.conferenceName ?? null,
       conferenceAcronym: meta?.conferenceAcronym ?? null,


### PR DESCRIPTION
- Use submissionAbstract instead of description for abstract field to properly
  separate submission metadata from poster description for SEO
- Extract citation identifier mapping into dedicated citationIdentifiers variable
- Update license field to use licenseInfo.value?.reference instead of raw license ID
- Expose submissionAbstract in API response from posterContent metadata

## Summary by Sourcery

Update discover poster ScholarlyArticle schema metadata to use correct abstract, citations, and license information sourced from poster metadata.

New Features:
- Expose submissionAbstract from posterContent metadata in the discover poster API response and front-end poster state.

Enhancements:
- Use submissionAbstract instead of description for the ScholarlyArticle abstract field to distinguish submission metadata from poster description.
- Derive citation identifiers for the ScholarlyArticle citation field from relatedIdentifiers with relationType 'Cites'.
- Populate the ScholarlyArticle license field from resolved licenseInfo.reference instead of the raw license identifier.