### PR TITLE
feat: ✨ Tombstone published posters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ shared/generated/*
 # Automated poster extraction
 merged/
 merged-backup/
+reports/
 
 # Database snapshots
 db-snapshots

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ shared/generated/*
 
 # Automated poster extraction
 merged/
+merged-backup/
 
 # Database snapshots
 db-snapshots

--- a/app/pages/admin/index.vue
+++ b/app/pages/admin/index.vue
@@ -850,7 +850,7 @@ const tabs = [
       "
       @update:open="
         (v) => {
-          if (!v && !isDeletingPoster) closeDeletePosterModal();
+          if (!v) closeDeletePosterModal();
         }
       "
     >
@@ -871,7 +871,6 @@ const tabs = [
             color="neutral"
             variant="outline"
             label="Cancel"
-            :disabled="isDeletingPoster"
             @click="closeDeletePosterModal"
           />
 

--- a/app/pages/admin/index.vue
+++ b/app/pages/admin/index.vue
@@ -26,6 +26,7 @@ type StatsResponse = {
     draft: number;
     downloaded: number;
     published: number;
+    tombstoned: number;
   };
 };
 
@@ -44,6 +45,8 @@ type PosterRow = {
   id: number;
   title: string;
   status: string;
+  tombstone: boolean;
+  tombedReason: string;
   publishedAt: string | null;
   created: string;
   user: {
@@ -254,19 +257,74 @@ const posterColumns: ColumnDef<PosterRow>[] = [
 ];
 
 const confirmDeletePosterId = ref<number | null>(null);
+const tombstoneReason = ref("");
+const isDeletingPoster = ref(false);
+const restoringPosterId = ref<number | null>(null);
+
+const posterToDelete = computed(
+  () => posters.value.find((p) => p.id === confirmDeletePosterId.value) ?? null,
+);
+
+function closeDeletePosterModal() {
+  confirmDeletePosterId.value = null;
+  tombstoneReason.value = "";
+}
 
 async function deletePoster() {
-  const poster = posters.value.find(
-    (p) => p.id === confirmDeletePosterId.value,
-  );
+  // Guard against a double click firing multiple DELETE requests before the
+  // first one resolves and closes the modal.
+  if (isDeletingPoster.value) return;
+
+  const poster = posterToDelete.value;
   if (!poster) return;
+
+  // Published posters are retired (tombstoned) with a required reason;
+  // drafts and downloads are hard-deleted.
+  const isPublished = poster.status === "published";
+  if (isPublished && tombstoneReason.value.trim() === "") {
+    toast.add({
+      title: "A reason is required to retire this poster",
+      color: "error",
+    });
+
+    return;
+  }
+
+  isDeletingPoster.value = true;
   try {
-    await $fetch(`/api/admin/posters/${poster.id}`, { method: "DELETE" });
-    toast.add({ title: `"${poster.title}" deleted`, color: "success" });
-    confirmDeletePosterId.value = null;
+    await $fetch(`/api/admin/posters/${poster.id}`, {
+      method: "DELETE",
+      body: isPublished ? { reason: tombstoneReason.value.trim() } : undefined,
+    });
+    toast.add({
+      title: `"${poster.title}" ${isPublished ? "retired" : "deleted"}`,
+      color: "success",
+    });
+    closeDeletePosterModal();
     await Promise.all([refreshPosters(), refreshStats(), refreshAuditLog()]);
   } catch {
-    toast.add({ title: "Failed to delete poster", color: "error" });
+    toast.add({
+      title: `Failed to ${isPublished ? "retire" : "delete"} poster`,
+      color: "error",
+    });
+  } finally {
+    isDeletingPoster.value = false;
+  }
+}
+
+async function restorePoster(poster: PosterRow) {
+  // Guard against a double click firing multiple restore requests.
+  if (restoringPosterId.value !== null) return;
+
+  restoringPosterId.value = poster.id;
+  try {
+    await $fetch(`/api/admin/posters/${poster.id}/restore`, { method: "POST" });
+    toast.add({ title: `"${poster.title}" restored`, color: "success" });
+    await Promise.all([refreshPosters(), refreshStats(), refreshAuditLog()]);
+  } catch {
+    toast.add({ title: "Failed to restore poster", color: "error" });
+  } finally {
+    restoringPosterId.value = null;
   }
 }
 
@@ -288,6 +346,8 @@ const auditTotal = computed(() => auditData.value?.total ?? 0);
 
 const actionLabels: Record<string, string> = {
   DELETE_POSTER: "Deleted poster",
+  TOMBSTONE_POSTER: "Retired poster",
+  RESTORE_POSTER: "Restored poster",
   DELETE_USER: "Deleted user",
   UPDATE_USER_ROLE: "Updated role",
 };
@@ -300,8 +360,16 @@ const auditColumns: ColumnDef<AuditLogRow>[] = [
     header: "Action",
   },
   { accessorKey: "entityId", header: "Entity ID" },
+  { id: "reason", header: "Reason", enableSorting: false },
   { accessorKey: "created", header: "Date" },
 ];
+
+// Pulls the retire reason out of an audit entry's free-form details JSON.
+function auditReason(log: AuditLogRow): string {
+  const reason = log.details?.reason;
+
+  return typeof reason === "string" ? reason : "";
+}
 
 // Helpers
 
@@ -310,6 +378,7 @@ const statusItems = [
   { label: "Draft", value: "draft" },
   { label: "Downloaded", value: "downloaded" },
   { label: "Published", value: "published" },
+  { label: "Tombstoned", value: "tombstoned" },
 ];
 
 function statusColor(s: string) {
@@ -356,7 +425,7 @@ const tabs = [
     <h1 class="mb-8 text-3xl font-bold">Admin Panel</h1>
 
     <!-- Stats cards -->
-    <div class="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+    <div class="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
       <UCard>
         <p class="text-muted text-sm">Total Users</p>
 
@@ -374,6 +443,16 @@ const tabs = [
 
         <p v-else class="mt-1 text-2xl font-bold">
           {{ stats?.posters.published ?? "-" }}
+        </p>
+      </UCard>
+
+      <UCard>
+        <p class="text-muted text-sm">Tombstoned Posters</p>
+
+        <USpinner v-if="statsStatus === 'pending'" size="sm" class="mt-1" />
+
+        <p v-else class="mt-1 text-2xl font-bold">
+          {{ stats?.posters.tombstoned ?? "-" }}
         </p>
       </UCard>
 
@@ -571,6 +650,16 @@ const tabs = [
 
           <template #status-cell="{ row }">
             <UBadge
+              v-if="row.original.tombstone"
+              color="warning"
+              variant="subtle"
+              size="sm"
+            >
+              Tombstoned
+            </UBadge>
+
+            <UBadge
+              v-else
               :color="statusColor(row.original.status)"
               variant="subtle"
               size="sm"
@@ -600,10 +689,29 @@ const tabs = [
           <template #posterActions-cell="{ row }">
             <div class="flex justify-end">
               <UButton
+                v-if="row.original.tombstone"
                 size="xs"
-                color="error"
+                color="neutral"
                 variant="outline"
-                icon="material-symbols:delete"
+                icon="material-symbols:restore-from-trash"
+                label="Restore"
+                :loading="restoringPosterId === row.original.id"
+                :disabled="restoringPosterId !== null"
+                @click="restorePoster(row.original)"
+              />
+
+              <UButton
+                v-else
+                size="xs"
+                :color="
+                  row.original.status === 'published' ? 'warning' : 'error'
+                "
+                variant="outline"
+                :icon="
+                  row.original.status === 'published'
+                    ? 'material-symbols:archive'
+                    : 'material-symbols:delete'
+                "
                 @click="confirmDeletePosterId = row.original.id"
               />
             </div>
@@ -663,6 +771,30 @@ const tabs = [
             }}</span>
           </template>
 
+          <template #reason-cell="{ row }">
+            <UPopover
+              v-if="
+                row.original.action === 'TOMBSTONE_POSTER' &&
+                auditReason(row.original)
+              "
+              mode="hover"
+            >
+              <span class="line-clamp-2 max-w-xs cursor-help text-sm">
+                {{ auditReason(row.original) }}
+              </span>
+
+              <template #content>
+                <p
+                  class="max-h-64 max-w-sm overflow-y-auto p-3 text-sm break-words whitespace-pre-wrap"
+                >
+                  {{ auditReason(row.original) }}
+                </p>
+              </template>
+            </UPopover>
+
+            <span v-else class="text-muted text-xs">-</span>
+          </template>
+
           <template #created-cell="{ row }">
             {{ formatDate(row.original.created) }}
           </template>
@@ -703,27 +835,59 @@ const tabs = [
       </template>
     </UModal>
 
-    <!-- Delete poster modal -->
+    <!-- Delete / retire poster modal -->
     <UModal
       :open="confirmDeletePosterId !== null"
-      title="Delete Poster"
-      description="This will permanently delete the poster and all associated metadata. This cannot be undone."
+      :title="
+        posterToDelete?.status === 'published'
+          ? 'Retire Poster'
+          : 'Delete Poster'
+      "
+      :description="
+        posterToDelete?.status === 'published'
+          ? 'This hides the poster from public view but preserves the record. A reason is required, and it can be restored later.'
+          : 'This will permanently delete the poster and all associated metadata. This cannot be undone.'
+      "
       @update:open="
         (v) => {
-          if (!v) confirmDeletePosterId = null;
+          if (!v && !isDeletingPoster) closeDeletePosterModal();
         }
       "
     >
+      <template v-if="posterToDelete?.status === 'published'" #body>
+        <UFormField label="Reason for retiring" required>
+          <UTextarea
+            v-model="tombstoneReason"
+            :rows="3"
+            placeholder="Explain why this poster is being retired"
+            class="w-full"
+          />
+        </UFormField>
+      </template>
+
       <template #footer>
         <div class="flex justify-end gap-2">
           <UButton
             color="neutral"
             variant="outline"
             label="Cancel"
-            @click="confirmDeletePosterId = null"
+            :disabled="isDeletingPoster"
+            @click="closeDeletePosterModal"
           />
 
-          <UButton color="error" label="Delete" @click="deletePoster" />
+          <UButton
+            color="error"
+            :label="
+              posterToDelete?.status === 'published' ? 'Retire' : 'Delete'
+            "
+            :loading="isDeletingPoster"
+            :disabled="
+              isDeletingPoster ||
+              (posterToDelete?.status === 'published' &&
+                tombstoneReason.trim() === '')
+            "
+            @click="deletePoster"
+          />
         </div>
       </template>
     </UModal>

--- a/app/pages/discover/[posterid]/index.vue
+++ b/app/pages/discover/[posterid]/index.vue
@@ -15,6 +15,13 @@ const { loggedIn } = useUserSession();
 const toast = useToast();
 const { siteEnv } = useRuntimeConfig().public;
 
+// Shares the global feedback modal state owned by the default layout, so we can
+// open the same "Share Your Feedback" dialog from this page.
+const feedbackOpen = useState("feedbackOpen", () => false);
+function openFeedback() {
+  feedbackOpen.value = true;
+}
+
 const { data: apiData, error } = await useFetch(`/api/discover/${posterId}`);
 
 if (error.value) {
@@ -977,6 +984,23 @@ const tabItems = [
                 </div>
               </div>
             </UCard>
+
+            <UAlert
+              color="info"
+              variant="soft"
+              icon="material-symbols:info-outline"
+              title="Is this your poster?"
+              description="Would you like it removed from our platform? Reach out and let us know this is your poster and that you would like it taken down."
+            >
+              <template #actions>
+                <UButton
+                  color="info"
+                  size="sm"
+                  label="Contact us"
+                  @click="openFeedback"
+                />
+              </template>
+            </UAlert>
           </div>
         </div>
       </UContainer>

--- a/app/pages/discover/[posterid]/index.vue
+++ b/app/pages/discover/[posterid]/index.vue
@@ -984,23 +984,6 @@ const tabItems = [
                 </div>
               </div>
             </UCard>
-
-            <UAlert
-              color="info"
-              variant="soft"
-              icon="material-symbols:info-outline"
-              title="Is this your poster?"
-              description="Would you like it removed from our platform? Reach out and let us know this is your poster and that you would like it taken down."
-            >
-              <template #actions>
-                <UButton
-                  color="info"
-                  size="sm"
-                  label="Contact us"
-                  @click="openFeedback"
-                />
-              </template>
-            </UAlert>
           </div>
         </div>
       </UContainer>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,11 +2,35 @@
 export default defineNuxtConfig({
   compatibilityDate: "2025-01-16",
   css: ["~/assets/css/main.css"],
-  devtools: { enabled: true },
   dayjs: {
     defaultLocale: "en",
     defaultTimezone: "America/Los_Angeles",
     plugins: ["relativeTime", "utc", "timezone"],
+  },
+  devtools: { enabled: true },
+  echarts: {
+    charts: ["BarChart", "PieChart", "LineChart"],
+    components: [
+      "DatasetComponent",
+      "GridComponent",
+      "TooltipComponent",
+      "ToolboxComponent",
+      "TitleComponent",
+      "LegendComponent",
+    ],
+  },
+  eslint: {},
+  icon: {
+    collections: [
+      "heroicons",
+      "lucide",
+      "material-symbols",
+      "simple-icons",
+      "vscode-icons",
+    ],
+  },
+  image: {
+    // Options
   },
   modules: [
     "@nuxt/ui",
@@ -20,31 +44,51 @@ export default defineNuxtConfig({
     "@nuxtjs/sitemap",
     "nuxt-schema-org",
   ],
-  icon: {
-    collections: [
-      "heroicons",
-      "lucide",
-      "material-symbols",
-      "simple-icons",
-      "vscode-icons",
-    ],
-  },
-  vite: {
-    optimizeDeps: {
-      include: [
-        "@inspira-ui/plugins", // CJS
-        "@internationalized/date",
-        "clsx",
-        "dayjs", // CJS
-        "dayjs/plugin/relativeTime", // CJS
-        "dayjs/plugin/timezone", // CJS
-        "dayjs/plugin/updateLocale", // CJS
-        "dayjs/plugin/utc", // CJS
-        "motion-v",
-        "vue3-lottie",
-        "zod",
-      ],
+  nitro: {
+    moduleSideEffects: ["@prisma/client", ".prisma/client"],
+    rollupConfig: {
+      external: ["@prisma/client", ".prisma/client"],
     },
+    experimental: {
+      openAPI: true,
+    },
+    openAPI: {
+      meta: {
+        title: "Posters.science API Documentation",
+        description: "API Documentation for Posters.science",
+      },
+      route: "/_docs/openapi.json",
+    },
+  },
+  robots: {
+    groups: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: [
+          "/admin/",
+          "/api/",
+          "/dashboard/",
+          "/forgot-password/",
+          "/liked/",
+          "/login/",
+          "/profile/",
+          "/share/",
+          "/signup/",
+        ],
+        contentUsage: {
+          bots: "y",
+          "train-ai": "n",
+          "ai-output": "n",
+          search: "y",
+        },
+        contentSignal: {
+          search: "yes",
+          "ai-input": "no",
+          "ai-train": "no",
+        },
+      },
+    ],
   },
   // Runtime config values can be overridden at container startup using NUXT_ prefixed env vars.
   // This works because Nuxt scans for NUXT_* env vars when the app starts (not at build time)
@@ -79,36 +123,21 @@ export default defineNuxtConfig({
       siteEnv: "",
     },
   },
-
-  eslint: {},
-  echarts: {
-    charts: ["BarChart", "PieChart", "LineChart"],
-    components: [
-      "DatasetComponent",
-      "GridComponent",
-      "TooltipComponent",
-      "ToolboxComponent",
-      "TitleComponent",
-      "LegendComponent",
-    ],
-  },
-  nitro: {
-    moduleSideEffects: ["@prisma/client", ".prisma/client"],
-    rollupConfig: {
-      external: ["@prisma/client", ".prisma/client"],
+  vite: {
+    optimizeDeps: {
+      include: [
+        "@inspira-ui/plugins", // CJS
+        "@internationalized/date",
+        "clsx",
+        "dayjs", // CJS
+        "dayjs/plugin/relativeTime", // CJS
+        "dayjs/plugin/timezone", // CJS
+        "dayjs/plugin/updateLocale", // CJS
+        "dayjs/plugin/utc", // CJS
+        "motion-v",
+        "vue3-lottie",
+        "zod",
+      ],
     },
-    experimental: {
-      openAPI: true,
-    },
-    openAPI: {
-      meta: {
-        title: "Posters.science API Documentation",
-        description: "API Documentation for Posters.science",
-      },
-      route: "/_docs/openapi.json",
-    },
-  },
-  image: {
-    // Options
   },
 });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -111,6 +111,9 @@ model Poster {
 
     automated Boolean @default(false) // Whether the poster was created through automated extraction or manual submission
 
+    tombstone    Boolean @default(false) // true = retired/soft-deleted, hidden from public views
+    tombedReason String  @default("") // Why the poster was retired
+
     likes Like[] @relation("PosterLikes")
 }
 

--- a/scripts/add-extracted-posters.ts
+++ b/scripts/add-extracted-posters.ts
@@ -66,6 +66,67 @@ type JsonPoster = {
   _license_blocked?: boolean;
 };
 
+function sanitizeText(value: string): string {
+  let out = "";
+
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+
+    // Remove ASCII control chars except tab/newline/carriage return.
+    if (
+      (code >= 0x00 && code <= 0x08) ||
+      code === 0x0b ||
+      code === 0x0c ||
+      (code >= 0x0e && code <= 0x1f) ||
+      code === 0x7f
+    ) {
+      continue;
+    }
+
+    // Keep only valid surrogate pairs; drop unpaired surrogates.
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const nextCode = i + 1 < value.length ? value.charCodeAt(i + 1) : -1;
+      if (nextCode >= 0xdc00 && nextCode <= 0xdfff) {
+        out += value[i] + value[i + 1];
+        i++;
+      }
+      continue;
+    }
+
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      continue;
+    }
+
+    out += value[i];
+  }
+
+  return out;
+}
+
+function sanitizeValue<T>(value: T): T {
+  if (typeof value === "string") {
+    return sanitizeText(value) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeValue(item)) as T;
+  }
+
+  if (value instanceof Date || value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === "object") {
+    const sanitizedEntries = Object.entries(
+      value as Record<string, unknown>,
+    ).map(([key, val]) => [key, sanitizeValue(val)]);
+
+    return Object.fromEntries(sanitizedEntries) as T;
+  }
+
+  return value;
+}
+
 function mapToDbFields(data: JsonPoster) {
   const creators = (data.creators ?? []).map((creator: any) => {
     // affiliation can be string[] or object[] depending on source
@@ -204,7 +265,7 @@ function mapToDbFields(data: JsonPoster) {
     caption: c.caption ?? "",
   }));
 
-  return {
+  return sanitizeValue({
     creators,
     imageCaptions,
     posterContent,
@@ -237,7 +298,7 @@ function mapToDbFields(data: JsonPoster) {
     conferenceAcronym,
     conferenceSeries,
     domain,
-  };
+  });
 }
 
 function getImageUrl(

--- a/scripts/add-extracted-posters.ts
+++ b/scripts/add-extracted-posters.ts
@@ -15,9 +15,10 @@ const prisma = new PrismaClient({ adapter });
  * Optional:
  *   --dir     path to merged folder (default: ./merged)
  *   --limit   max number of posters to import (default: all)
+ *   --error-report path to JSON error report output
  *
- * Posters are upserted by DOI URL (https://doi.org/<doi>).
- * If a poster with the same DOI already exists it will be updated; otherwise created.
+ * Posters are matched by DOI when available.
+ * If DOI is missing, fallback matching uses case-insensitive title + identifiers overlap.
  */
 function getArg(name: string): string | undefined {
   const idx = process.argv.indexOf(`--${name}`);
@@ -296,11 +297,86 @@ function collectJsonFiles(mergedDir: string): string[] {
   return files;
 }
 
+function normalizeIdentifierValue(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+
+  return normalized.length > 0 ? normalized : null;
+}
+
+function collectIdentifierTokens(identifiers: unknown): Set<string> {
+  const tokens = new Set<string>();
+  if (!Array.isArray(identifiers)) return tokens;
+
+  for (const raw of identifiers) {
+    if (!raw || typeof raw !== "object") continue;
+
+    const entry = raw as {
+      identifier?: unknown;
+      identifierType?: unknown;
+      nameIdentifier?: unknown;
+      nameIdentifierType?: unknown;
+      relatedIdentifier?: unknown;
+      relatedIdentifierType?: unknown;
+    };
+
+    const identifier =
+      normalizeIdentifierValue(entry.identifier) ??
+      normalizeIdentifierValue(entry.nameIdentifier) ??
+      normalizeIdentifierValue(entry.relatedIdentifier);
+
+    if (!identifier) continue;
+
+    const type =
+      normalizeIdentifierValue(entry.identifierType) ??
+      normalizeIdentifierValue(entry.nameIdentifierType) ??
+      normalizeIdentifierValue(entry.relatedIdentifierType) ??
+      "unknown";
+
+    tokens.add(`${type}|${identifier}`);
+  }
+
+  return tokens;
+}
+
+function hasIdentifierOverlap(a: Set<string>, b: Set<string>): boolean {
+  if (a.size === 0 || b.size === 0) return false;
+
+  for (const token of a) {
+    if (b.has(token)) return true;
+  }
+
+  return false;
+}
+
+type ErrorReportItem = {
+  index: number;
+  filePath: string;
+  fileName: string;
+  phase: "parse" | "upsert";
+  message: string;
+  doi: string | null;
+  title: string | null;
+  publisher: string | null;
+};
+
+function createDefaultErrorReportPath(cwd: string): string {
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+
+  return path.join(
+    cwd,
+    "reports",
+    `add-extracted-posters-errors-${stamp}.json`,
+  );
+}
+
 async function main() {
   const userId = "0";
   const limitArg = getArg("limit");
   const limit = limitArg ? Number(limitArg) : Infinity;
   const mergedDir = getArg("dir") ?? path.join(process.cwd(), "merged");
+  const errorReportPath =
+    getArg("error-report") ?? createDefaultErrorReportPath(process.cwd());
 
   console.log(`\n Importing posters for userId: ${userId}`);
 
@@ -310,7 +386,7 @@ async function main() {
   let created = 0;
   let updated = 0;
   let errored = 0;
-  let skipped = 0;
+  const erroredItems: ErrorReportItem[] = [];
 
   for (let i = 0; i < allFiles.length; i++) {
     const filePath = allFiles[i];
@@ -323,19 +399,23 @@ async function main() {
     let data: JsonPoster;
     try {
       data = JSON.parse(raw) as JsonPoster;
-    } catch {
+    } catch (err: any) {
       console.warn(`     Could not parse ${filePath}`);
+      erroredItems.push({
+        index: i,
+        filePath,
+        fileName: path.basename(filePath),
+        phase: "parse",
+        message: err?.message ?? "Could not parse JSON",
+        doi: null,
+        title: null,
+        publisher: null,
+      });
       errored++;
       continue;
     }
 
     const mapped = mapToDbFields(data);
-
-    if (!mapped.doi) {
-      console.log(`    [skipped] Missing DOI: ${path.basename(filePath)}`);
-      skipped++;
-      continue;
-    }
 
     const imageUrl = getImageUrl(
       filePath,
@@ -344,18 +424,60 @@ async function main() {
       data._license_blocked,
     );
 
-    // The unique key is the DOI URL (https://doi.org/<doi>)
-    const existingMetadata = mapped.doi
-      ? await prisma.posterMetadata.findFirst({
+    let existingMetadata: { posterId: number } | null = null;
+
+    if (mapped.doi) {
+      // Primary match path: DOI
+      existingMetadata = await prisma.posterMetadata.findFirst({
+        where: {
+          poster: {
+            automated: true,
+            published: true,
+          },
+          doi: {
+            equals: mapped.doi,
+            mode: "insensitive",
+          },
+        },
+        select: { posterId: true },
+      });
+    }
+
+    if (!existingMetadata && !mapped.doi) {
+      // Fallback match path for no-DOI records: title + identifiers overlap.
+      const title = mapped.posterTitle.trim();
+      const incomingIdentifierTokens = collectIdentifierTokens(
+        mapped.identifiers,
+      );
+
+      if (title.length > 0 && incomingIdentifierTokens.size > 0) {
+        const candidates = await prisma.posterMetadata.findMany({
           where: {
-            doi: {
-              equals: mapped.doi,
-              mode: "insensitive",
+            poster: {
+              automated: true,
+              published: true,
+              title: {
+                equals: title,
+                mode: "insensitive",
+              },
             },
           },
-          select: { posterId: true },
-        })
-      : null;
+          select: {
+            posterId: true,
+            identifiers: true,
+          },
+        });
+
+        const match = candidates.find((candidate) =>
+          hasIdentifierOverlap(
+            incomingIdentifierTokens,
+            collectIdentifierTokens(candidate.identifiers),
+          ),
+        );
+
+        existingMetadata = match ? { posterId: match.posterId } : null;
+      }
+    }
 
     const metadataPayload = {
       doi: mapped.doi,
@@ -448,12 +570,39 @@ async function main() {
       }
     } catch (err: any) {
       console.warn(`    Failed: ${filePath}\n      ${err?.message}`);
+      erroredItems.push({
+        index: i,
+        filePath,
+        fileName: path.basename(filePath),
+        phase: "upsert",
+        message: err?.message ?? "Unknown upsert error",
+        doi: mapped.doi,
+        title: mapped.posterTitle,
+        publisher: mapped.publisher,
+      });
       errored++;
     }
   }
 
+  if (erroredItems.length > 0) {
+    const reportPayload = {
+      generatedAt: new Date().toISOString(),
+      mergedDir,
+      totals: {
+        created,
+        updated,
+        errored,
+      },
+      items: erroredItems,
+    };
+
+    fs.mkdirSync(path.dirname(errorReportPath), { recursive: true });
+    fs.writeFileSync(errorReportPath, JSON.stringify(reportPayload, null, 2));
+    console.log(`Error report written to: ${errorReportPath}`);
+  }
+
   console.log(
-    `\n🎉 Done. Created: ${created}, Updated: ${updated}, Skipped: ${skipped}, Errored: ${errored}\n`,
+    `\n🎉 Done. Created: ${created}, Updated: ${updated}, Errored: ${errored}\n`,
   );
 }
 

--- a/scripts/add-extracted-posters.ts
+++ b/scripts/add-extracted-posters.ts
@@ -125,7 +125,21 @@ function mapToDbFields(data: JsonPoster) {
   const doiRaw = doiEntry?.identifier;
   const doi = typeof doiRaw === "string" ? doiRaw.toLowerCase() : null;
 
-  const publisher = "Zenodo";
+  const publisherName =
+    typeof data.publisher === "string"
+      ? data.publisher
+      : data.publisher && typeof data.publisher === "object"
+        ? (data.publisher as { name?: unknown }).name
+        : null;
+
+  const publisher =
+    typeof publisherName === "string" && publisherName.trim().length > 0
+      ? publisherName.trim()
+      : doi && /figshare/i.test(doi)
+        ? "Figshare"
+        : doi && /zenodo/i.test(doi)
+          ? "Zenodo"
+          : null;
 
   const publicationYear = data.publicationYear ?? null;
 
@@ -228,6 +242,7 @@ function mapToDbFields(data: JsonPoster) {
 function getImageUrl(
   filePath: string,
   doi: string | null,
+  publisher?: unknown,
   licenseBlocked?: boolean,
 ): string {
   const basename = path.basename(filePath); // e.g. "12345678_complete.json"
@@ -239,11 +254,24 @@ function getImageUrl(
 
   if (!doi) return "";
 
-  const lower = doi.toLowerCase();
+  const publisherName =
+    typeof publisher === "string"
+      ? publisher
+      : publisher && typeof publisher === "object"
+        ? (publisher as { name?: unknown }).name
+        : null;
+
+  const publisherText = typeof publisherName === "string" ? publisherName : "";
   let source: "zenodo" | "figshare" | null = null;
 
-  if (lower.includes("zenodo")) source = "zenodo";
-  else if (lower.includes("figshare")) source = "figshare";
+  // Prefer publisher metadata first, then DOI/path fallbacks.
+  if (/figshare/i.test(publisherText)) source = "figshare";
+  else if (/zenodo/i.test(publisherText)) source = "zenodo";
+  else if (/zenodo/i.test(doi)) source = "zenodo";
+  else if (/figshare/i.test(doi)) source = "figshare";
+  else if (/\/zenodo\//i.test(filePath)) source = "zenodo";
+  else if (/\/figshare\//i.test(filePath)) source = "figshare";
+
   if (!source) return "";
 
   return `https://cdn.posters.science/thumbnails/a/${source}_${id}.jpeg`;
@@ -309,7 +337,12 @@ async function main() {
       continue;
     }
 
-    const imageUrl = getImageUrl(filePath, mapped.doi, data._license_blocked);
+    const imageUrl = getImageUrl(
+      filePath,
+      mapped.doi,
+      data.publisher,
+      data._license_blocked,
+    );
 
     // The unique key is the DOI URL (https://doi.org/<doi>)
     const existingMetadata = mapped.doi

--- a/scripts/add-extracted-posters.ts
+++ b/scripts/add-extracted-posters.ts
@@ -432,7 +432,7 @@ async function main() {
         where: {
           poster: {
             automated: true,
-            published: true,
+            status: "published",
           },
           doi: {
             equals: mapped.doi,
@@ -455,7 +455,7 @@ async function main() {
           where: {
             poster: {
               automated: true,
-              published: true,
+              status: "published",
               title: {
                 equals: title,
                 mode: "insensitive",

--- a/scripts/add-extracted-posters.ts
+++ b/scripts/add-extracted-posters.ts
@@ -282,6 +282,7 @@ async function main() {
   let created = 0;
   let updated = 0;
   let errored = 0;
+  let skipped = 0;
 
   for (let i = 0; i < allFiles.length; i++) {
     const filePath = allFiles[i];
@@ -301,6 +302,13 @@ async function main() {
     }
 
     const mapped = mapToDbFields(data);
+
+    if (!mapped.doi) {
+      console.log(`    [skipped] Missing DOI: ${path.basename(filePath)}`);
+      skipped++;
+      continue;
+    }
+
     const imageUrl = getImageUrl(filePath, mapped.doi, data._license_blocked);
 
     // The unique key is the DOI URL (https://doi.org/<doi>)
@@ -412,7 +420,7 @@ async function main() {
   }
 
   console.log(
-    `\n🎉 Done. Created: ${created}, Updated: ${updated}, Errored: ${errored}\n`,
+    `\n🎉 Done. Created: ${created}, Updated: ${updated}, Skipped: ${skipped}, Errored: ${errored}\n`,
   );
 }
 

--- a/server/api/admin/posters/[id].delete.ts
+++ b/server/api/admin/posters/[id].delete.ts
@@ -1,3 +1,9 @@
+import { z } from "zod";
+
+const bodySchema = z.object({
+  reason: z.string().trim().min(1),
+});
+
 export default defineEventHandler(async (event) => {
   const session = await requireAdminSession(event);
   const posterId = Number(getRouterParam(event, "id"));
@@ -8,12 +14,44 @@ export default defineEventHandler(async (event) => {
 
   const existing = await prisma.poster.findUnique({
     where: { id: posterId },
-    select: { id: true, title: true, userId: true },
+    select: { id: true, title: true, userId: true, status: true },
   });
   if (!existing) {
     throw createError({ statusCode: 404, statusMessage: "Poster not found" });
   }
 
+  // Published posters are never hard-deleted. Instead they are tombstoned
+  // (retired) so the record is preserved with a documented reason.
+  if (existing.status === "published") {
+    const body = await readValidatedBody(event, (b) => bodySchema.safeParse(b));
+    if (!body.success) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: "A reason is required to retire a published poster",
+      });
+    }
+
+    await prisma.poster.update({
+      where: { id: posterId },
+      data: { tombstone: true, tombedReason: body.data.reason },
+    });
+
+    await logAdminAction({
+      adminUserId: session.user.id,
+      action: "TOMBSTONE_POSTER",
+      entityType: "poster",
+      entityId: String(posterId),
+      details: {
+        title: existing.title,
+        ownerId: existing.userId,
+        reason: body.data.reason,
+      },
+    });
+
+    return { success: true, tombstoned: true };
+  }
+
+  // Draft / downloaded posters are never public, so a hard delete is fine.
   await prisma.poster.delete({ where: { id: posterId } });
 
   await logAdminAction({
@@ -24,5 +62,5 @@ export default defineEventHandler(async (event) => {
     details: { title: existing.title, ownerId: existing.userId },
   });
 
-  return { success: true };
+  return { success: true, deleted: true };
 });

--- a/server/api/admin/posters/[id]/restore.post.ts
+++ b/server/api/admin/posters/[id]/restore.post.ts
@@ -1,0 +1,38 @@
+export default defineEventHandler(async (event) => {
+  const session = await requireAdminSession(event);
+  const posterId = Number(getRouterParam(event, "id"));
+
+  if (isNaN(posterId)) {
+    throw createError({ statusCode: 400, statusMessage: "Invalid poster id" });
+  }
+
+  const existing = await prisma.poster.findUnique({
+    where: { id: posterId },
+    select: { id: true, title: true, userId: true, tombstone: true },
+  });
+  if (!existing) {
+    throw createError({ statusCode: 404, statusMessage: "Poster not found" });
+  }
+
+  if (!existing.tombstone) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Poster is not tombstoned",
+    });
+  }
+
+  await prisma.poster.update({
+    where: { id: posterId },
+    data: { tombstone: false, tombedReason: "" },
+  });
+
+  await logAdminAction({
+    adminUserId: session.user.id,
+    action: "RESTORE_POSTER",
+    entityType: "poster",
+    entityId: String(posterId),
+    details: { title: existing.title, ownerId: existing.userId },
+  });
+
+  return { success: true, restored: true };
+});

--- a/server/api/admin/posters/index.get.ts
+++ b/server/api/admin/posters/index.get.ts
@@ -24,7 +24,11 @@ export default defineEventHandler(async (event) => {
           ],
         }
       : {}),
-    ...(status ? { status } : {}),
+    ...(status === "tombstoned"
+      ? { tombstone: true }
+      : status
+        ? { status }
+        : {}),
   };
 
   const [posters, total] = await Promise.all([
@@ -34,6 +38,8 @@ export default defineEventHandler(async (event) => {
         id: true,
         title: true,
         status: true,
+        tombstone: true,
+        tombedReason: true,
         publishedAt: true,
         created: true,
         user: {

--- a/server/api/admin/stats.get.ts
+++ b/server/api/admin/stats.get.ts
@@ -1,27 +1,38 @@
 export default defineEventHandler(async (event) => {
   await requireAdminSession(event);
 
-  const [totalUsers, postersByStatus, pendingJobs] = await Promise.all([
-    prisma.user.count(),
-    prisma.poster.groupBy({
-      by: ["status"],
-      _count: { id: true },
-    }),
-    prisma.extractionJob.count({
-      where: { status: { in: ["pending-extraction", "processing"] } },
-    }),
-  ]);
+  const [totalUsers, postersByStatus, tombstonedCount, pendingJobs] =
+    await Promise.all([
+      prisma.user.count(),
+      // Live posters only. Tombstoned (retired) posters keep their underlying
+      // status, so they are excluded here and counted separately below.
+      prisma.poster.groupBy({
+        by: ["status"],
+        where: { tombstone: false },
+        _count: { id: true },
+      }),
+      prisma.poster.count({ where: { tombstone: true } }),
+      prisma.extractionJob.count({
+        where: { status: { in: ["pending-extraction", "processing"] } },
+      }),
+    ]);
 
   const posterCounts = {
-    total: postersByStatus.reduce((sum, g) => sum + g._count.id, 0),
+    total: 0,
     draft: 0,
     downloaded: 0,
     published: 0,
+    tombstoned: tombstonedCount,
   } as Record<string, number>;
 
+  let liveTotal = 0;
   for (const group of postersByStatus) {
     posterCounts[group.status] = group._count.id;
+    liveTotal += group._count.id;
   }
+
+  // Total counts every poster that still exists, tombstoned included.
+  posterCounts.total = liveTotal + tombstonedCount;
 
   return { totalUsers, posters: posterCounts, pendingJobs };
 });

--- a/server/api/discover/[posterid]/index.get.ts
+++ b/server/api/discover/[posterid]/index.get.ts
@@ -9,7 +9,7 @@ export default defineEventHandler(async (event) => {
   }
 
   const poster = await prisma.poster.findFirst({
-    where: { id: posterId, status: "published" },
+    where: { id: posterId, status: "published", tombstone: false },
     include: {
       user: { select: { givenName: true, familyName: true } },
       posterMetadata: true,

--- a/server/api/discover/[posterid]/like.get.ts
+++ b/server/api/discover/[posterid]/like.get.ts
@@ -10,7 +10,7 @@ export default defineEventHandler(async (event) => {
   }
 
   const poster = await prisma.poster.findFirst({
-    where: { id: posterId, status: "published" },
+    where: { id: posterId, status: "published", tombstone: false },
     select: { id: true },
   });
 

--- a/server/api/discover/facets.get.ts
+++ b/server/api/discover/facets.get.ts
@@ -53,7 +53,7 @@ export default defineEventHandler(async (event): Promise<FacetsResponse> => {
     prisma.posterMetadata.groupBy({
       by: ["language"],
       where: {
-        poster: { status: "published" },
+        poster: { status: "published", tombstone: false },
         language: { not: null },
       },
       _count: { _all: true },
@@ -63,7 +63,7 @@ export default defineEventHandler(async (event): Promise<FacetsResponse> => {
     prisma.posterMetadata.groupBy({
       by: ["license"],
       where: {
-        poster: { status: "published" },
+        poster: { status: "published", tombstone: false },
         license: { not: null },
       },
       _count: { _all: true },
@@ -73,7 +73,7 @@ export default defineEventHandler(async (event): Promise<FacetsResponse> => {
     prisma.posterMetadata.groupBy({
       by: ["publicationYear"],
       where: {
-        poster: { status: "published" },
+        poster: { status: "published", tombstone: false },
         publicationYear: { not: null, gte: 2000, lte: currentYear },
       },
       _count: { _all: true },
@@ -99,6 +99,7 @@ export default defineEventHandler(async (event): Promise<FacetsResponse> => {
                THEN creator->'affiliation' ELSE '[]'::jsonb END
         ) AS aff
         WHERE p.status = 'published'
+          AND p.tombstone = false
         GROUP BY institution
       ) sub
       WHERE institution IS NOT NULL AND institution != ''
@@ -121,6 +122,7 @@ export default defineEventHandler(async (event): Promise<FacetsResponse> => {
              THEN pm."fundingReferences" ELSE '[]'::jsonb END
       ) AS fr
       WHERE p.status = 'published'
+        AND p.tombstone = false
         AND fr->>'funderName' IS NOT NULL
         AND fr->>'funderName' <> ''
     `,

--- a/server/api/discover/index.get.ts
+++ b/server/api/discover/index.get.ts
@@ -139,7 +139,7 @@ export default defineEventHandler(async (event) => {
   if (licenseCanonicalValues.length > 0) {
     const rawLicenses = await prisma.posterMetadata.findMany({
       where: {
-        poster: { status: "published" },
+        poster: { status: "published", tombstone: false },
         license: { not: null },
       },
       select: { license: true },
@@ -169,6 +169,7 @@ export default defineEventHandler(async (event) => {
              THEN creator->'affiliation' ELSE '[]'::jsonb END
       ) AS aff
       WHERE p.status = 'published'
+        AND p.tombstone = false
         AND lower(trim(
           CASE
             WHEN jsonb_typeof(aff) = 'object' THEN aff->>'name'
@@ -198,6 +199,7 @@ export default defineEventHandler(async (event) => {
              THEN pm."fundingReferences" ELSE '[]'::jsonb END
       ) AS fr
       WHERE p.status = 'published'
+        AND p.tombstone = false
         AND fr->>'funderName' IS NOT NULL
         AND fr->>'funderName' <> ''
     `;
@@ -235,6 +237,7 @@ export default defineEventHandler(async (event) => {
 
   const whereClause = {
     status: "published",
+    tombstone: false,
     ...searchFilter,
     ...sourceFilter,
     ...metadataFilter,

--- a/server/api/discover/stats.get.ts
+++ b/server/api/discover/stats.get.ts
@@ -2,6 +2,7 @@ export default defineEventHandler(async () => {
   const manual = await prisma.poster.count({
     where: {
       status: "published",
+      tombstone: false,
       automated: false,
     },
   });
@@ -9,6 +10,7 @@ export default defineEventHandler(async () => {
   const automation = await prisma.poster.count({
     where: {
       status: "published",
+      tombstone: false,
       automated: true,
     },
   });

--- a/server/utils/computeMetrics.ts
+++ b/server/utils/computeMetrics.ts
@@ -53,15 +53,20 @@ export async function computeMetrics(client: PrismaClient) {
     languageCountResult,
   ] = await Promise.all([
     // 1) count of published posters that are manually shared
-    client.poster.count({ where: { status: "published", automated: false } }),
+    client.poster.count({
+      where: { status: "published", tombstone: false, automated: false },
+    }),
     // 2) count of published posters that are auto-indexed
-    client.poster.count({ where: { status: "published", automated: true } }),
+    client.poster.count({
+      where: { status: "published", tombstone: false, automated: true },
+    }),
 
     // 3) monthly trend (last 13 months, client fills full 12-month window)
     client.$queryRaw<Array<{ month: Date; count: number }>>`
       SELECT DATE_TRUNC('month', created) AS month, COUNT(*)::int AS count
       FROM "Poster"
       WHERE status = 'published'
+        AND tombstone = false
         AND created >= NOW() - INTERVAL '13 months'
       GROUP BY month
       ORDER BY month ASC
@@ -70,7 +75,10 @@ export async function computeMetrics(client: PrismaClient) {
     // 5) top 10 domains
     client.posterMetadata.groupBy({
       by: ["domain"],
-      where: { poster: { status: "published" }, domain: { not: null } },
+      where: {
+        poster: { status: "published", tombstone: false },
+        domain: { not: null },
+      },
       _count: { _all: true },
       orderBy: { _count: { domain: "desc" } },
       take: 10,
@@ -79,7 +87,10 @@ export async function computeMetrics(client: PrismaClient) {
     // 6) full language distribution (collapsed to top 3 + "Other" below)
     client.posterMetadata.groupBy({
       by: ["language"],
-      where: { poster: { status: "published" }, language: { not: null } },
+      where: {
+        poster: { status: "published", tombstone: false },
+        language: { not: null },
+      },
       _count: { _all: true },
       orderBy: { _count: { language: "desc" } },
     }),
@@ -87,7 +98,10 @@ export async function computeMetrics(client: PrismaClient) {
     // 7) top 50 licenses
     client.posterMetadata.groupBy({
       by: ["license"],
-      where: { poster: { status: "published" }, license: { not: null } },
+      where: {
+        poster: { status: "published", tombstone: false },
+        license: { not: null },
+      },
       _count: { _all: true },
       orderBy: { _count: { license: "desc" } },
       take: 50, // fetch more before normalization merges duplicates
@@ -97,7 +111,10 @@ export async function computeMetrics(client: PrismaClient) {
     // highest-count variant supplies the display name)
     client.posterMetadata.groupBy({
       by: ["publisher"],
-      where: { poster: { status: "published" }, publisher: { not: null } },
+      where: {
+        poster: { status: "published", tombstone: false },
+        publisher: { not: null },
+      },
       _count: { _all: true },
       orderBy: { _count: { publisher: "desc" } },
     }),
@@ -106,7 +123,7 @@ export async function computeMetrics(client: PrismaClient) {
     client.posterMetadata.groupBy({
       by: ["conferenceYear"],
       where: {
-        poster: { status: "published" },
+        poster: { status: "published", tombstone: false },
         conferenceYear: { not: null },
       },
       _count: { _all: true },
@@ -117,7 +134,7 @@ export async function computeMetrics(client: PrismaClient) {
     client.posterMetadata.groupBy({
       by: ["conferenceName"],
       where: {
-        poster: { status: "published" },
+        poster: { status: "published", tombstone: false },
         conferenceName: { not: null },
       },
       _count: { _all: true },
@@ -133,6 +150,7 @@ export async function computeMetrics(client: PrismaClient) {
       FROM "PosterMetadata" pm
       JOIN "Poster" p ON pm."posterId" = p.id
       WHERE p.status = 'published'
+        AND p.tombstone = false
         AND subjects IS NOT NULL
         AND array_length(subjects, 1) > 0
       GROUP BY subject
@@ -161,6 +179,7 @@ export async function computeMetrics(client: PrismaClient) {
                THEN creator->'affiliation' ELSE '[]'::jsonb END
         ) AS aff
         WHERE p.status = 'published'
+          AND p.tombstone = false
       ) sub
       WHERE institution IS NOT NULL AND institution != ''
         AND trim(institution) !~ '^[0-9]+$'
@@ -190,6 +209,7 @@ export async function computeMetrics(client: PrismaClient) {
                THEN creator->'affiliation' ELSE '[]'::jsonb END
         ) AS aff
         WHERE p.status = 'published'
+          AND p.tombstone = false
         GROUP BY institution
       ) sub
       WHERE institution IS NOT NULL AND institution != ''
@@ -206,7 +226,7 @@ export async function computeMetrics(client: PrismaClient) {
     client.posterMetadata.groupBy({
       by: ["publicationYear"],
       where: {
-        poster: { status: "published" },
+        poster: { status: "published", tombstone: false },
         publicationYear: { not: null, gte: 2000, lte: currentYear },
       },
       _count: { _all: true },
@@ -219,6 +239,7 @@ export async function computeMetrics(client: PrismaClient) {
       FROM "PosterMetadata" pm
       JOIN "Poster" p ON pm."posterId" = p.id
       WHERE p.status = 'published'
+        AND p.tombstone = false
         AND pm.doi IS NOT NULL
         AND pm.doi <> ''
     `,
@@ -256,6 +277,7 @@ export async function computeMetrics(client: PrismaClient) {
         JOIN "Poster" p ON pm."posterId" = p.id
         CROSS JOIN LATERAL jsonb_array_elements(pm.creators) AS cr
         WHERE p.status = 'published'
+          AND p.tombstone = false
           AND jsonb_typeof(pm.creators) = 'array'
       )
       SELECT
@@ -282,6 +304,7 @@ export async function computeMetrics(client: PrismaClient) {
              THEN creator->'affiliation' ELSE '[]'::jsonb END
       ) AS aff
       WHERE p.status = 'published'
+        AND p.tombstone = false
         AND aff->>'affiliationIdentifierScheme' = 'ROR'
         AND aff->>'affiliationIdentifier' <> ''
     `,
@@ -300,6 +323,7 @@ export async function computeMetrics(client: PrismaClient) {
              THEN pm."fundingReferences" ELSE '[]'::jsonb END
       ) AS fr
       WHERE p.status = 'published'
+        AND p.tombstone = false
         AND fr->>'funderName' IS NOT NULL
         AND fr->>'funderName' <> ''
     `,
@@ -310,6 +334,7 @@ export async function computeMetrics(client: PrismaClient) {
       FROM "PosterMetadata" pm
       JOIN "Poster" p ON pm."posterId" = p.id
       WHERE p.status = 'published'
+        AND p.tombstone = false
         AND pm.language IS NOT NULL
         AND pm.language <> ''
     `,


### PR DESCRIPTION
## Summary by Sourcery

Introduce tombstoning for published posters and integrate the concept across admin UI, APIs, metrics, and discovery so retired posters are hidden but restorable and auditable.

New Features:
- Add support for tombstoning (retiring) published posters with a required reason and the ability to restore them from the admin panel.
- Expose tombstoned poster counts and status in admin stats, filters, tables, and audit logs.
- Enhance poster import to handle DOI-based and identifier-based matching, dynamic publisher inference, text sanitization, and error reporting.

Enhancements:
- Exclude tombstoned posters from public discovery, stats, and metrics calculations while keeping their records intact.
- Refine admin delete flows to differentiate between hard deletion for non-public posters and tombstoning for published posters.
- Improve Nuxt configuration structure and add robots rules to restrict access to admin, auth, and API routes while signalling content usage preferences.