### PR TITLE
feat: add sitemaps

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,11 +2,35 @@
 export default defineNuxtConfig({
   compatibilityDate: "2025-01-16",
   css: ["~/assets/css/main.css"],
-  devtools: { enabled: true },
   dayjs: {
     defaultLocale: "en",
     defaultTimezone: "America/Los_Angeles",
     plugins: ["relativeTime", "utc", "timezone"],
+  },
+  devtools: { enabled: true },
+  echarts: {
+    charts: ["BarChart", "PieChart", "LineChart"],
+    components: [
+      "DatasetComponent",
+      "GridComponent",
+      "TooltipComponent",
+      "ToolboxComponent",
+      "TitleComponent",
+      "LegendComponent",
+    ],
+  },
+  eslint: {},
+  icon: {
+    collections: [
+      "heroicons",
+      "lucide",
+      "material-symbols",
+      "simple-icons",
+      "vscode-icons",
+    ],
+  },
+  image: {
+    // Options
   },
   modules: [
     "@nuxt/ui",
@@ -20,31 +44,51 @@ export default defineNuxtConfig({
     "@nuxtjs/sitemap",
     "nuxt-schema-org",
   ],
-  icon: {
-    collections: [
-      "heroicons",
-      "lucide",
-      "material-symbols",
-      "simple-icons",
-      "vscode-icons",
-    ],
-  },
-  vite: {
-    optimizeDeps: {
-      include: [
-        "@inspira-ui/plugins", // CJS
-        "@internationalized/date",
-        "clsx",
-        "dayjs", // CJS
-        "dayjs/plugin/relativeTime", // CJS
-        "dayjs/plugin/timezone", // CJS
-        "dayjs/plugin/updateLocale", // CJS
-        "dayjs/plugin/utc", // CJS
-        "motion-v",
-        "vue3-lottie",
-        "zod",
-      ],
+  nitro: {
+    moduleSideEffects: ["@prisma/client", ".prisma/client"],
+    rollupConfig: {
+      external: ["@prisma/client", ".prisma/client"],
     },
+    experimental: {
+      openAPI: true,
+    },
+    openAPI: {
+      meta: {
+        title: "Posters.science API Documentation",
+        description: "API Documentation for Posters.science",
+      },
+      route: "/_docs/openapi.json",
+    },
+  },
+  robots: {
+    groups: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: [
+          "/admin/",
+          "/api/",
+          "/dashboard/",
+          "/forgot-password/",
+          "/liked/",
+          "/login/",
+          "/profile/",
+          "/share/",
+          "/signup/",
+        ],
+        contentUsage: {
+          bots: "y",
+          "train-ai": "n",
+          "ai-output": "n",
+          search: "y",
+        },
+        contentSignal: {
+          search: "yes",
+          "ai-input": "no",
+          "ai-train": "no",
+        },
+      },
+    ],
   },
   // Runtime config values can be overridden at container startup using NUXT_ prefixed env vars.
   // This works because Nuxt scans for NUXT_* env vars when the app starts (not at build time)
@@ -79,36 +123,21 @@ export default defineNuxtConfig({
       siteEnv: "",
     },
   },
-
-  eslint: {},
-  echarts: {
-    charts: ["BarChart", "PieChart", "LineChart"],
-    components: [
-      "DatasetComponent",
-      "GridComponent",
-      "TooltipComponent",
-      "ToolboxComponent",
-      "TitleComponent",
-      "LegendComponent",
-    ],
-  },
-  nitro: {
-    moduleSideEffects: ["@prisma/client", ".prisma/client"],
-    rollupConfig: {
-      external: ["@prisma/client", ".prisma/client"],
+  vite: {
+    optimizeDeps: {
+      include: [
+        "@inspira-ui/plugins", // CJS
+        "@internationalized/date",
+        "clsx",
+        "dayjs", // CJS
+        "dayjs/plugin/relativeTime", // CJS
+        "dayjs/plugin/timezone", // CJS
+        "dayjs/plugin/updateLocale", // CJS
+        "dayjs/plugin/utc", // CJS
+        "motion-v",
+        "vue3-lottie",
+        "zod",
+      ],
     },
-    experimental: {
-      openAPI: true,
-    },
-    openAPI: {
-      meta: {
-        title: "Posters.science API Documentation",
-        description: "API Documentation for Posters.science",
-      },
-      route: "/_docs/openapi.json",
-    },
-  },
-  image: {
-    // Options
   },
 });

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,4 +1,21 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+// Protected routes that should not be indexed by search engines or crawlers.
+const PROTECTED_ROUTES = [
+  "/admin",
+  "/api",
+  "/dashboard",
+  "/forgot-password",
+  "/liked",
+  "/login",
+  "/profile",
+  "/reset-password",
+  "/share/new",
+  "/signup",
+  "/verify-email",
+  "/zenodo-auth-error",
+  "/404",
+];
+
 export default defineNuxtConfig({
   compatibilityDate: "2025-01-16",
   css: ["~/assets/css/main.css"],
@@ -65,17 +82,7 @@ export default defineNuxtConfig({
       {
         userAgent: "*",
         allow: "/",
-        disallow: [
-          "/admin/",
-          "/api/",
-          "/dashboard/",
-          "/forgot-password/",
-          "/liked/",
-          "/login/",
-          "/profile/",
-          "/share/",
-          "/signup/",
-        ],
+        disallow: PROTECTED_ROUTES,
         contentUsage: {
           bots: "y",
           "train-ai": "n",
@@ -98,24 +105,11 @@ export default defineNuxtConfig({
     sitemaps: {
       pages: {
         includeAppSources: true,
-        exclude: [
-          "/admin/**",
-          "/dashboard/**",
-          "/forgot-password/**",
-          "/liked/**",
-          "/login/**",
-          "/profile/**",
-          "/reset-password/**",
-          "/share/**",
-          "/signup/**",
-          "/verify-email/**",
-          "/zenodo-auth-error/**",
-          "/discover/[poster-id]/**",
-          "/schemas/**",
-        ],
+        exclude: PROTECTED_ROUTES,
       },
       posters: {
         sources: ["/api/__sitemap__/posters"],
+        chunks: 10000, // Chunk size should be increased to 25000 once total poster count exceeds 100k
       },
     },
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -123,36 +123,6 @@ export default defineNuxtConfig({
       route: "/_docs/openapi.json",
     },
   },
-  robots: {
-    groups: [
-      {
-        userAgent: "*",
-        allow: "/",
-        disallow: [
-          "/admin/",
-          "/api/",
-          "/dashboard/",
-          "/forgot-password/",
-          "/liked/",
-          "/login/",
-          "/profile/",
-          "/share/",
-          "/signup/",
-        ],
-        contentUsage: {
-          bots: "y",
-          "train-ai": "n",
-          "ai-output": "n",
-          search: "y",
-        },
-        contentSignal: {
-          search: "yes",
-          "ai-input": "no",
-          "ai-train": "no",
-        },
-      },
-    ],
-  },
   // Runtime config values can be overridden at container startup using NUXT_ prefixed env vars.
   // This works because Nuxt scans for NUXT_* env vars when the app starts (not at build time)
   // and automatically maps them to runtimeConfig keys:

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -92,6 +92,32 @@ export default defineNuxtConfig({
   },
   site: {
     url: process.env.NUXT_SITE_URL || "http://localhost:3000",
+    name: "Posters.science",
+  },
+  sitemap: {
+    sitemaps: {
+      pages: {
+        includeAppSources: true,
+        exclude: [
+          "/admin/**",
+          "/dashboard/**",
+          "/forgot-password/**",
+          "/liked/**",
+          "/login/**",
+          "/profile/**",
+          "/reset-password/**",
+          "/share/**",
+          "/signup/**",
+          "/verify-email/**",
+          "/zenodo-auth-error/**",
+          "/discover/[poster-id]/**",
+          "/schemas/**",
+        ],
+      },
+      posters: {
+        sources: ["/api/__sitemap__/posters"],
+      },
+    },
   },
   // Runtime config values can be overridden at container startup using NUXT_ prefixed env vars.
   // This works because Nuxt scans for NUXT_* env vars when the app starts (not at build time)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -90,6 +90,9 @@ export default defineNuxtConfig({
       },
     ],
   },
+  site: {
+    url: process.env.NUXT_SITE_URL || "http://localhost:3000",
+  },
   // Runtime config values can be overridden at container startup using NUXT_ prefixed env vars.
   // This works because Nuxt scans for NUXT_* env vars when the app starts (not at build time)
   // and automatically maps them to runtimeConfig keys:

--- a/server/api/__sitemap__/posters.ts
+++ b/server/api/__sitemap__/posters.ts
@@ -1,5 +1,7 @@
 export default defineSitemapEventHandler(async () => {
-  const { siteEnv } = useRuntimeConfig();
+  const {
+    public: { siteEnv },
+  } = useRuntimeConfig();
 
   if (siteEnv === "staging") {
     return [];
@@ -9,6 +11,7 @@ export default defineSitemapEventHandler(async () => {
     const posters = await prisma.poster.findMany({
       where: {
         status: "published",
+        tombstone: false,
       },
       select: {
         id: true,

--- a/server/api/__sitemap__/posters.ts
+++ b/server/api/__sitemap__/posters.ts
@@ -1,0 +1,23 @@
+export default defineSitemapEventHandler(async () => {
+  // Fetch all published posters
+  console.log("Fetching published posters for sitemap...");
+  let posters = [];
+  try {
+    posters = await prisma.poster.findMany({
+      where: { status: "published" },
+      select: { id: true },
+    });
+  } catch (error) {
+    console.error("Error fetching posters for sitemap:", error);
+
+    return [];
+  }
+
+  console.log(
+    `Found ${posters.length} published posters for sitemap generation.`,
+  );
+
+  return posters.map((poster) => ({
+    loc: `/discover/${poster.id}`,
+  }));
+});

--- a/server/api/__sitemap__/posters.ts
+++ b/server/api/__sitemap__/posters.ts
@@ -1,23 +1,41 @@
 export default defineSitemapEventHandler(async () => {
-  // Fetch all published posters
-  console.log("Fetching published posters for sitemap...");
-  let posters = [];
-  try {
-    posters = await prisma.poster.findMany({
-      where: { status: "published" },
-      select: { id: true },
-    });
-  } catch (error) {
-    console.error("Error fetching posters for sitemap:", error);
+  const { siteEnv } = useRuntimeConfig();
 
+  if (siteEnv === "staging") {
     return [];
   }
 
-  console.log(
-    `Found ${posters.length} published posters for sitemap generation.`,
-  );
+  try {
+    const posters = await prisma.poster.findMany({
+      where: {
+        status: "published",
+      },
+      select: {
+        id: true,
+        updated: true,
+        imageUrl: true,
+      },
+      orderBy: {
+        id: "asc",
+      },
+    });
 
-  return posters.map((poster) => ({
-    loc: `/discover/${poster.id}`,
-  }));
+    return posters.map((poster) => ({
+      loc: `/discover/${poster.id}`,
+      ...(poster.updated && {
+        lastmod: poster.updated.toISOString(),
+      }),
+      ...(poster.imageUrl && {
+        images: [
+          {
+            loc: poster.imageUrl,
+          },
+        ],
+      }),
+    }));
+  } catch (error) {
+    console.error("Failed to generate poster sitemap:", error);
+
+    return [];
+  }
 });


### PR DESCRIPTION
## Summary by Sourcery

Configure sitemap and robots rules for the site and add dynamic sitemap generation for posters.

New Features:
- Add sitemap configuration with separate sitemaps for static pages and dynamic poster content.
- Introduce dynamic posters sitemap endpoint fed from the database via Prisma.

Enhancements:
- Define shared list of protected routes for use in robots and sitemap exclusion lists.
- Configure robots.txt rules to block protected routes and disallow AI training and output usage for bots.
- Add site metadata configuration (URL and name) and consolidate nuxt.config sections without changing behavior.