### PR TITLE
feat: ✨ ROR lookup support for funder identifiers

### DIFF
--- a/app/components/identifier/IdentifierRorSearch.vue
+++ b/app/components/identifier/IdentifierRorSearch.vue
@@ -5,10 +5,14 @@ interface RorResult {
   country: string;
 }
 
-const props = defineProps<{
-  open: boolean;
-  initialQuery: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    open: boolean;
+    initialQuery: string;
+    nameLabel?: string;
+  }>(),
+  { nameLabel: "affiliation" },
+);
 
 const emit = defineEmits<{
   (e: "update:open", value: boolean): void;
@@ -190,7 +194,7 @@ function selectResult(result: RorResult) {
     </template>
   </UDrawer>
 
-  <UModal v-model:open="confirmOpen" title="Replace affiliation name?">
+  <UModal v-model:open="confirmOpen" :title="`Replace ${nameLabel} name?`">
     <template #body>
       <p class="text-sm text-gray-600 dark:text-gray-400">
         The current name

--- a/app/pages/share/[id]/index.vue
+++ b/app/pages/share/[id]/index.vue
@@ -18,6 +18,7 @@ import {
   normalizeNameIdentifierToUrl,
   normalizeAffiliationIdentifierToUrl,
   schemeUriForScheme,
+  isCanonicalSchemeUri,
   extractOrcidId,
   validateOrcidExists,
 } from "@/utils/poster_schema";
@@ -28,6 +29,8 @@ import {
 } from "@internationalized/date";
 import DatePicker from "~/components/ui/DatePicker.vue";
 import DateRangePicker from "~/components/ui/DateRangePicker.vue";
+
+type FundingReference = StrictFormSchema["fundingReferences"][number];
 
 definePageMeta({
   middleware: ["auth"],
@@ -56,6 +59,7 @@ const affiliationIdentifierErrors = ref<Record<string, string | undefined>>({});
 const orcidSearchOpenIndex = ref<number | null>(null);
 const rorSearchOpenIndex = ref<number | null>(null);
 const affiliationRorSearchOpen = ref<string | null>(null);
+const funderRorSearchOpen = ref<number | null>(null);
 const autofillHighlight = ref<Record<string, boolean>>({});
 
 function handleOrcidSelect(orcidUrl: string, cIndex: number) {
@@ -380,23 +384,33 @@ if (data.value) {
     if (meta.format) state.format = meta.format;
     if (meta.license) state.license = meta.license;
 
-    // Funding references - cast funderIdentifierType to enum
+    // Funding references - cast funderIdentifierType to enum, and back-fill the
+    // type/schemeUri pair for records saved before those were derived
     if (meta.fundingReferences?.length) {
-      state.fundingReferences = meta.fundingReferences.map((f: any) => ({
-        funderName: f.funderName || "",
-        funderIdentifier: f.funderIdentifier || "",
-        funderIdentifierType: f.funderIdentifierType as
-          | "Crossref Funder ID"
-          | "GRID"
-          | "ISNI"
-          | "ROR"
-          | "Other"
-          | undefined,
-        schemeUri: f.schemeUri || "",
-        awardNumber: f.awardNumber || "",
-        awardUri: f.awardUri || "",
-        awardTitle: f.awardTitle || "",
-      }));
+      state.fundingReferences = meta.fundingReferences.map((f: any) => {
+        const funder: FundingReference = {
+          funderName: f.funderName || "",
+          funderIdentifier: f.funderIdentifier || "",
+          funderIdentifierType: (f.funderIdentifierType ||
+            (f.funderIdentifier
+              ? inferFunderIdentifierType(f.funderIdentifier)
+              : undefined)) as FundingReference["funderIdentifierType"],
+          schemeUri: f.schemeUri || "",
+          awardNumber: f.awardNumber || "",
+          awardUri: f.awardUri || "",
+          awardTitle: f.awardTitle || "",
+        };
+
+        // The field is hidden for derivable types, so make sure the stored value
+        // matches the type rather than leaving a stale one the user cannot see
+        if (
+          funder.funderIdentifierType &&
+          funder.funderIdentifierType !== "Other"
+        )
+          syncFunderSchemeUri(funder);
+
+        return funder;
+      });
     }
 
     // Conference
@@ -928,11 +942,47 @@ function handleAffiliationRorSelect(
   }, 700);
 }
 
+// Keeps schemeUri in step with the identifier type. Every type except "Other" has a
+// canonical URI we can derive, so the field stays hidden for those.
+function syncFunderSchemeUri(
+  funder: FundingReference,
+  type = funder.funderIdentifierType,
+) {
+  if (!type) {
+    funder.schemeUri = "";
+
+    return;
+  }
+
+  if (type === "Other") {
+    // Drop an auto-derived value so the user supplies their own
+    if (isCanonicalSchemeUri(funder.schemeUri)) funder.schemeUri = "";
+
+    return;
+  }
+
+  funder.schemeUri = schemeUriForScheme(type) ?? funder.schemeUri;
+}
+
+// The ROR lookup only applies while the row is still empty or already ROR.
+// Once the row commits to another scheme (Crossref Funder ID, GRID, ISNI, Other) the
+// button would only produce a mismatched identifier, so hide it.
+function showFunderRorSearch(funder: FundingReference) {
+  const identifier = funder.funderIdentifier?.trim();
+  const type =
+    funder.funderIdentifierType ??
+    (identifier ? inferFunderIdentifierType(identifier) : undefined);
+
+  return !type || type === "ROR";
+}
+
 function handleFunderIdentifierTypeChange(value: string, fIndex: number) {
   const funder = state.fundingReferences[fIndex];
   if (!funder) return;
-  const uri = schemeUriForScheme(value);
-  if (uri) funder.schemeUri ||= uri;
+  syncFunderSchemeUri(
+    funder,
+    value as FundingReference["funderIdentifierType"],
+  );
 }
 
 function handleFunderIdentifierInput(value: string, fIndex: number) {
@@ -940,6 +990,34 @@ function handleFunderIdentifierInput(value: string, fIndex: number) {
   if (!funder) return;
   const inferred = inferFunderIdentifierType(value);
   if (inferred) funder.funderIdentifierType ||= inferred;
+  syncFunderSchemeUri(funder);
+}
+
+function clearFunderIdentifierType(fIndex: number) {
+  const funder = state.fundingReferences[fIndex];
+  if (!funder) return;
+  funder.funderIdentifierType = undefined;
+  syncFunderSchemeUri(funder);
+}
+
+function handleFunderRorSelect(
+  rorUrl: string,
+  displayName: string,
+  fIndex: number,
+) {
+  const funder = state.fundingReferences[fIndex];
+  if (funder) {
+    funder.funderName = displayName;
+    funder.funderIdentifier = rorUrl;
+    funder.funderIdentifierType = "ROR";
+    syncFunderSchemeUri(funder);
+  }
+  funderRorSearchOpen.value = null;
+  const key = `funder-${fIndex}`;
+  autofillHighlight.value[key] = true;
+  setTimeout(() => {
+    autofillHighlight.value[key] = false;
+  }, 700);
 }
 
 async function addSubjectAndFocus() {
@@ -2029,44 +2107,118 @@ const moveCreator = (index: number, direction: "up" | "down") => {
                     />
                   </div>
 
-                  <div class="grid gap-3 md:grid-cols-2">
-                    <UFormField
-                      :name="`fundingReferences.${fIndex}.funderIdentifier`"
-                      label="Funder Identifier"
-                    >
-                      <UInput
-                        v-model="funder.funderIdentifier"
-                        placeholder="https://ror.org/04xfq0f34"
-                        @update:model-value="
-                          (v) => handleFunderIdentifierInput(String(v), fIndex)
-                        "
-                      />
-                    </UFormField>
-
+                  <div class="grid items-start gap-3 md:grid-cols-2">
                     <UFormField
                       :name="`fundingReferences.${fIndex}.funderIdentifierType`"
                       label="Identifier Type"
                     >
-                      <USelect
-                        v-model="funder.funderIdentifierType"
-                        :items="FUNDER_IDENTIFIER_TYPE_OPTIONS"
-                        placeholder="Select a type"
+                      <div class="flex items-center gap-1">
+                        <USelect
+                          v-model="funder.funderIdentifierType"
+                          :items="FUNDER_IDENTIFIER_TYPE_OPTIONS"
+                          placeholder="Select a type"
+                          class="w-full"
+                          @update:model-value="
+                            (v) =>
+                              handleFunderIdentifierTypeChange(
+                                String(v),
+                                fIndex,
+                              )
+                          "
+                        />
+
+                        <UButton
+                          v-if="funder.funderIdentifierType"
+                          class="shrink-0"
+                          size="xs"
+                          color="neutral"
+                          variant="ghost"
+                          icon="i-lucide-x"
+                          aria-label="Clear identifier type"
+                          @click="clearFunderIdentifierType(fIndex)"
+                        />
+                      </div>
+                    </UFormField>
+
+                    <div class="flex gap-2">
+                      <UFormField
+                        :name="`fundingReferences.${fIndex}.funderIdentifier`"
+                        label="Funder Identifier"
                         class="w-full"
-                        @update:model-value="
-                          (v) =>
-                            handleFunderIdentifierTypeChange(String(v), fIndex)
+                      >
+                        <div class="relative">
+                          <div
+                            v-if="autofillHighlight[`funder-${fIndex}`]"
+                            class="orcid-autofill-ring pointer-events-none absolute inset-0 rounded-md"
+                          />
+
+                          <UInput
+                            v-model="funder.funderIdentifier"
+                            placeholder="https://ror.org/04xfq0f34"
+                            class="w-full"
+                            @update:model-value="
+                              (v) =>
+                                handleFunderIdentifierInput(String(v), fIndex)
+                            "
+                          >
+                            <template
+                              v-if="funder.funderIdentifier?.startsWith('http')"
+                              #trailing
+                            >
+                              <a
+                                :href="funder.funderIdentifier"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="hover:text-primary-500 flex items-center text-gray-400"
+                              >
+                                <UIcon
+                                  name="i-lucide-external-link"
+                                  class="size-4 cursor-pointer"
+                                />
+                              </a>
+                            </template>
+                          </UInput>
+                        </div>
+                      </UFormField>
+
+                      <UButton
+                        v-if="showFunderRorSearch(funder)"
+                        class="mt-6 shrink-0"
+                        size="xs"
+                        variant="outline"
+                        icon="i-lucide-search"
+                        label="Find ROR"
+                        @click="funderRorSearchOpen = fIndex"
+                      />
+
+                      <IdentifierRorSearch
+                        v-if="funderRorSearchOpen === fIndex"
+                        :open="funderRorSearchOpen === fIndex"
+                        :initial-query="funder.funderName"
+                        name-label="funder"
+                        @update:open="
+                          (v) => {
+                            if (!v) funderRorSearchOpen = null;
+                          }
+                        "
+                        @select="
+                          (rorUrl, displayName) =>
+                            handleFunderRorSelect(rorUrl, displayName, fIndex)
                         "
                       />
-                    </UFormField>
+                    </div>
                   </div>
 
                   <UFormField
+                    v-if="funder.funderIdentifierType === 'Other'"
                     :name="`fundingReferences.${fIndex}.schemeUri`"
                     label="Scheme URI"
+                    :required="!!funder.funderIdentifier"
+                    description="The base URI of the identifier scheme this funder ID belongs to."
                   >
                     <UInput
                       v-model="funder.schemeUri"
-                      placeholder="https://ror.org"
+                      placeholder="https://example.org/identifiers"
                       class="w-full"
                     />
                   </UFormField>

--- a/app/utils/poster_schema.ts
+++ b/app/utils/poster_schema.ts
@@ -183,6 +183,19 @@ export function schemeUriForScheme(scheme: string): string | undefined {
   }
 }
 
+// Canonical schemeURI values produced by schemeUriForScheme. Used to tell an
+// auto-derived scheme URI apart from one the user typed in themselves.
+const CANONICAL_SCHEME_URIS = new Set(
+  ["ORCID", "ISNI", "ROR", "GRID", "Crossref Funder ID"].map(
+    (scheme) => schemeUriForScheme(scheme)!,
+  ),
+);
+
+// True when the value is one of the canonical scheme URIs (i.e. it was auto-filled).
+export function isCanonicalSchemeUri(value: string | undefined): boolean {
+  return !!value && CANONICAL_SCHEME_URIS.has(value.trim());
+}
+
 // Converts a bare name identifier (ORCID, ISNI) to its full URL form per DataCite 4.7.
 // If the value is already a URL, returns it unchanged.
 export function normalizeNameIdentifierToUrl(
@@ -781,7 +794,19 @@ const StrictFundingSchema = z
   .refine((data) => !data.funderIdentifier || data.funderIdentifierType, {
     message: "Identifier type is required when identifier is provided",
     path: ["funderIdentifierType"],
-  });
+  })
+  // Every other identifier type has a canonical scheme URI we fill in automatically,
+  // so "Other" is the only case where the user has to supply one.
+  .refine(
+    (data) =>
+      data.funderIdentifierType !== "Other" ||
+      !data.funderIdentifier?.trim() ||
+      !!data.schemeUri?.trim(),
+    {
+      message: "Scheme URI is required when the identifier type is Other",
+      path: ["schemeUri"],
+    },
+  );
 
 const StrictConferenceSchema = z.object({
   conferenceName: z.string().min(1, { message: "Conference name is required" }),

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -141,7 +141,7 @@ model PosterMetadata {
 
     license String? // SPDX identifier
 
-    fundingReferences Json @default("[]") // [{ funderName: string, funderIdentifier: string, funderIdentifierType: string, awardNumber: string, awardUri: string, awardTitle: string }]
+    fundingReferences Json @default("[]") // [{ funderName: string, funderIdentifier: string, funderIdentifierType: string, schemeUri: string, awardNumber: string, awardUri: string, awardTitle: string }]
 
     conferenceName           String?
     conferenceLocation       String?

--- a/scripts/dev/check-license-doi.ts
+++ b/scripts/dev/check-license-doi.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { PrismaClient } from "../../shared/generated/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import "dotenv/config";
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+const prisma = new PrismaClient({ adapter });
+
+interface LiceEntry {
+  id: number;
+  license: string | null;
+  doi: string;
+}
+
+async function main() {
+  const entries: LiceEntry[] = JSON.parse(readFileSync("lice.json", "utf-8"));
+
+  let missingRecords = 0;
+  let updatedCount = 0;
+
+  for (const [index, entry] of entries.entries()) {
+    process.stdout.write(`\rProcessing ${index + 1}/${entries.length}...`);
+
+    const record = await prisma.posterMetadata.findFirst({
+      where: { doi: entry.doi, poster: { automated: true, tombstone: false } },
+      select: { posterId: true, license: true },
+    });
+
+    if (!record) {
+      missingRecords++;
+      console.log(`doi=${entry.doi}: no PosterMetadata record found`);
+      continue;
+    }
+
+    if (record.license === null) {
+      await prisma.posterMetadata.update({
+        where: { posterId: record.posterId },
+        data: { license: entry.license },
+      });
+      updatedCount++;
+      console.log(
+        `doi=${entry.doi}: db license was null, set to "${entry.license}" (posterId=${record.posterId})`,
+      );
+    }
+  }
+
+  console.log("\n---");
+  console.log(`Total entries: ${entries.length}`);
+  console.log(`Missing DB records (no doi match): ${missingRecords}`);
+  console.log(`Licenses updated: ${updatedCount}`);
+}
+
+main()
+  .catch((error) => {
+    console.error("Failed:", error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/server/api/poster/[id]/index.put.ts
+++ b/server/api/poster/[id]/index.put.ts
@@ -1,6 +1,7 @@
 import { flattenError } from "zod";
 import {
   strictFormSchema,
+  schemeUriForScheme,
   type StrictFormSchema,
 } from "~~/app/utils/poster_schema";
 
@@ -116,7 +117,19 @@ export default defineEventHandler(async (event) => {
   const format = data.format || null;
   const version = data.version || null;
   const license = data.license || null;
-  const fundingReferences = data.fundingReferences ?? [];
+  // The review form derives schemeUri from the identifier type and hides the field for
+  // every type except "Other", so back-stop it here: a draft save skips validation, and
+  // older records were stored before the value was derived. Types without a canonical
+  // URI ("Other") are left alone for the user to fill in.
+  const fundingReferences = (
+    Array.isArray(data.fundingReferences) ? data.fundingReferences : []
+  ).map((funder) => {
+    if (funder.schemeUri?.trim() || !funder.funderIdentifierType) return funder;
+
+    const derived = schemeUriForScheme(funder.funderIdentifierType);
+
+    return derived ? { ...funder, schemeUri: derived } : funder;
+  });
 
   const { conference } = data;
   const conferenceName = conference?.conferenceName ?? null;


### PR DESCRIPTION
## Summary by Sourcery

Add ROR lookup and scheme URI handling for funder identifiers and introduce a utility script for backfilling licenses from a JSON source.

New Features:
- Enable ROR search and selection for funder identifiers in the share poster form, including autofill of funder name and identifier.
- Support automatic derivation and synchronization of funder scheme URIs from identifier types, with a manual scheme URI field when the type is Other.
- Allow the ROR search component to be reused for different entity types via a configurable name label prop.

Bug Fixes:
- Backfill scheme URIs for existing and draft funding reference records on save to ensure consistent identifier metadata.

Enhancements:
- Tighten funding reference validation to require a scheme URI when the identifier type is Other and an identifier is present.
- Introduce a helper to detect canonical scheme URIs and keep stored scheme values aligned with inferred identifier types.

Chores:
- Add a development script to check automated poster records against a JSON file and populate missing license values.