### PR TITLE
feat: :sparkles: Download poster bulk in discover page

### DIFF
--- a/app/pages/discover/index.vue
+++ b/app/pages/discover/index.vue
@@ -375,6 +375,25 @@ function clearAllFilters() {
       ]"
     />
 
+    <UAlert
+      icon="i-lucide-info"
+      color="info"
+      variant="soft"
+      title="Download the full poster record in bulk"
+      description="All poster records are archived on Zenodo in JSON format, making it convenient to download them for large scale analysis."
+      :actions="[
+        {
+          label: 'Read the Bulk Corpus guide',
+          to: 'https://docs.posters.science/docs/bulk-corpus.html',
+          target: '_blank',
+          icon: 'i-lucide-external-link',
+          trailing: true,
+          color: 'info',
+          variant: 'solid',
+        },
+      ]"
+    />
+
     <div class="flex gap-6">
       <div class="hidden w-80 flex-shrink-0 md:block">
         <UCard class="sticky top-4">


### PR DESCRIPTION
## Summary by Sourcery

Add a bulk download information alert to the discover page to promote access to the full poster corpus.

New Features:
- Display an informational alert on the discover page describing bulk poster record download via Zenodo and linking to the Bulk Corpus guide.

Documentation:
- Surface a link to the external Bulk Corpus guide from the discover page to document how to download poster records in bulk.