### PR TITLE
feat: ✨ Poster Versioning

### DIFF
--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -48,6 +48,9 @@ type Poster = {
   activeVersionDraft?: {
     id: number;
     versionSequence: number;
+    imageUrl: string;
+    title: string;
+    description: string;
     extractionJob?: {
       id?: string;
       status: string;
@@ -57,7 +60,34 @@ type Poster = {
   } | null;
 };
 
+type VersionJobStatusResponse = {
+  completed: boolean;
+  status: string;
+  posterId?: number;
+  error?: string | null;
+  imageUrl?: string;
+  title?: string;
+  description?: string;
+};
+
 const posters = ref<Poster[]>([]);
+const showTombstonedPosters = useCookie<boolean>(
+  "dashboard-show-tombstoned-posters",
+  {
+    default: () => true,
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: "lax",
+  },
+);
+
+const tombstonedPosterCount = computed(
+  () => posters.value.filter((poster) => poster.tombstone).length,
+);
+const visiblePosters = computed(() =>
+  showTombstonedPosters.value
+    ? posters.value
+    : posters.value.filter((poster) => !poster.tombstone),
+);
 
 const { data, error, refresh } = await useFetch("/api/poster");
 
@@ -78,6 +108,8 @@ const modalPublisher = ref("");
 const isSaving = ref(false);
 const doiError = ref("");
 const toast = useToast();
+const tombstoneModalOpen = ref(false);
+const tombstonedPoster = ref<Poster | null>(null);
 
 const versionModalOpen = ref(false);
 const versionPoster = ref<Poster | null>(null);
@@ -93,32 +125,35 @@ const deletingVersionDraft = ref(false);
 const pollingVersionJobId = ref<string | null>(null);
 let versionPollTimer: ReturnType<typeof setTimeout> | undefined;
 let versionPollGeneration = 0;
+const pollingVersionThumbnailJobId = ref<string | null>(null);
+let versionThumbnailPollTimer: ReturnType<typeof setTimeout> | undefined;
+let versionThumbnailPollGeneration = 0;
 
 const versionFileOptions = [
   {
-    label: "Reuse the current poster file",
+    label: "Keep the current poster file",
     description:
-      "For a new release where the poster is unchanged but its supplemental metadata need to be updated.",
+      "Choose this when the poster is unchanged but its supplemental metadata need to be updated.",
     value: "reuse",
   },
   {
-    label: "Upload a new PDF or image",
+    label: "Replace the poster file",
     description:
-      "For a revised poster with changes to its content, design, or file.",
+      "Upload a revised PDF or image when the poster itself has changed.",
     value: "upload",
   },
 ];
 const versionMetadataOptions = [
   {
-    label: "Start with the existing metadata",
+    label: "Keep and edit the current metadata",
     description:
-      "Best for smaller poster revisions. The copied metadata remains editable during review.",
+      "Best for smaller poster revisions. Copies the published metadata so you can make targeted edits without waiting for another extraction.",
     value: "copy",
   },
   {
-    label: "Extract metadata from the new poster file",
+    label: "Extract metadata from the replacement file",
     description:
-      "Best when the poster content changed enough that the existing metadata may be outdated.",
+      "Best when the poster content changed enough. Use the new poster to extract new metadata for your review.",
     value: "extract",
   },
 ];
@@ -170,19 +205,26 @@ const versionExtractionStatus = computed(() => {
     return {
       title: "Extracting poster metadata",
       description:
-        "The extraction service is analyzing the poster and saving the fields you’ll review and edit next.",
+        "The extraction service is analyzing the poster and saving the fields you'll review and edit next.",
     };
   }
 
   return {
-    title: "Preparing your version",
-    description: "The version draft is being prepared.",
+    title: "Preparing your edits",
+    description: "Your editable draft is being prepared.",
   };
 });
 
 const extractingVersionPoster = computed(() =>
   posters.value.find((poster) =>
     isVersionExtracting(poster.activeVersionDraft),
+  ),
+);
+const posterAwaitingDraftThumbnail = computed(() =>
+  posters.value.find(
+    (poster) =>
+      poster.activeVersionDraft?.extractionJob?.id &&
+      !poster.activeVersionDraft.imageUrl,
   ),
 );
 
@@ -199,19 +241,18 @@ function versionActionLabel(poster: Poster) {
     return "View extraction progress";
   }
   if (isVersionExtractionFailed(poster.activeVersionDraft)) {
-    return "View extraction error";
+    return "Resolve extraction issue";
   }
-  if (poster.activeVersionDraft) return "Review new version";
 
-  return "Publish new version";
+  return "Edit";
 }
 
 function versionActionTooltip(poster: Poster) {
   if (isVersionExtracting(poster.activeVersionDraft)) {
-    return "Open the version panel to view metadata extraction progress.";
+    return "Open the edit panel to view metadata extraction progress.";
   }
   if (isVersionExtractionFailed(poster.activeVersionDraft)) {
-    return "Open the version panel to view the extraction error.";
+    return "Open the edit panel to review the extraction issue.";
   }
   if (
     extractingVersionPoster.value &&
@@ -221,15 +262,17 @@ function versionActionTooltip(poster: Poster) {
   }
 
   return poster.activeVersionDraft
-    ? "Review the version draft before publishing it."
-    : "Create a new version of this poster.";
+    ? "Continue editing this published poster."
+    : "Edit this published poster. Publishing your changes creates a new version.";
 }
 
 function displayedVersion(poster: Poster) {
   if (poster.status !== "published") return null;
-  if (!poster.automated) return String(poster.versionSequence);
+  if (poster.automated) return poster.posterMetadata.version?.trim() || null;
 
-  return poster.posterMetadata.version?.trim() || null;
+  return (
+    poster.posterMetadata.version?.trim() || String(poster.versionSequence)
+  );
 }
 
 watch(versionFileMode, (mode) => {
@@ -279,6 +322,36 @@ function updateLocalVersionJob(
   }
 }
 
+function updateLocalVersionThumbnail(
+  posterId: number | undefined,
+  imageUrl: string | undefined,
+) {
+  if (!posterId || !imageUrl) return;
+
+  const poster = posters.value.find(
+    (candidate) => candidate.activeVersionDraft?.id === posterId,
+  );
+  if (poster?.activeVersionDraft) {
+    poster.activeVersionDraft.imageUrl = imageUrl;
+  }
+}
+
+function updateLocalVersionDetails(
+  posterId: number | undefined,
+  title: string | undefined,
+  description: string | undefined,
+) {
+  if (!posterId) return;
+
+  const draft = posters.value.find(
+    (poster) => poster.activeVersionDraft?.id === posterId,
+  )?.activeVersionDraft;
+  if (!draft) return;
+
+  if (title !== undefined) draft.title = title;
+  if (description !== undefined) draft.description = description;
+}
+
 async function refreshPosterList() {
   const openRootId = versionPoster.value?.rootPosterId;
   await refresh();
@@ -299,6 +372,58 @@ function stopVersionExtractionPolling() {
   }
 }
 
+function stopVersionThumbnailPolling() {
+  versionThumbnailPollGeneration += 1;
+  pollingVersionThumbnailJobId.value = null;
+  if (versionThumbnailPollTimer) {
+    clearTimeout(versionThumbnailPollTimer);
+    versionThumbnailPollTimer = undefined;
+  }
+}
+
+function startVersionThumbnailPolling(jobId: string) {
+  if (pollingVersionThumbnailJobId.value === jobId) return;
+
+  stopVersionThumbnailPolling();
+  pollingVersionThumbnailJobId.value = jobId;
+  const generation = versionThumbnailPollGeneration;
+  let attempts = 0;
+
+  const checkThumbnail = async () => {
+    if (generation !== versionThumbnailPollGeneration) return;
+
+    try {
+      const response = await $fetch<VersionJobStatusResponse>(
+        `/api/poster/job/${jobId}`,
+      );
+
+      if (generation !== versionThumbnailPollGeneration) return;
+      if (response.imageUrl) {
+        updateLocalVersionThumbnail(response.posterId, response.imageUrl);
+        pollingVersionThumbnailJobId.value = null;
+
+        return;
+      }
+    } catch {
+      // Keep the published thumbnail visible and retry while the draft
+      // thumbnail is being generated.
+    }
+
+    attempts += 1;
+    if (attempts >= 40) {
+      pollingVersionThumbnailJobId.value = null;
+
+      return;
+    }
+
+    if (generation === versionThumbnailPollGeneration) {
+      versionThumbnailPollTimer = setTimeout(checkThumbnail, 3000);
+    }
+  };
+
+  void checkThumbnail();
+}
+
 function startVersionExtractionPolling(jobId: string) {
   if (pollingVersionJobId.value === jobId) return;
 
@@ -310,12 +435,9 @@ function startVersionExtractionPolling(jobId: string) {
     if (generation !== versionPollGeneration) return;
 
     try {
-      const response = await $fetch<{
-        completed: boolean;
-        status: string;
-        posterId?: number;
-        error?: string | null;
-      }>(`/api/poster/job/${jobId}`);
+      const response = await $fetch<VersionJobStatusResponse>(
+        `/api/poster/job/${jobId}`,
+      );
 
       if (generation !== versionPollGeneration) return;
 
@@ -325,6 +447,12 @@ function startVersionExtractionPolling(jobId: string) {
         response.status,
         response.completed,
         response.error,
+      );
+      updateLocalVersionThumbnail(response.posterId, response.imageUrl);
+      updateLocalVersionDetails(
+        response.posterId,
+        response.title,
+        response.description,
       );
 
       if (response.completed && response.status === "completed") {
@@ -341,8 +469,8 @@ function startVersionExtractionPolling(jobId: string) {
 
           toast.add({
             title: completedDraft
-              ? `Version ${completedDraft.versionSequence} is ready to review`
-              : "Your new version is ready to review",
+              ? `Your edits for version ${completedDraft.versionSequence} are ready to review`
+              : "Your edits are ready to review",
             description: completedPoster
               ? `Metadata extraction finished for ${completedPoster.title}. Select the poster to continue reviewing it.`
               : "Metadata extraction finished. Select the poster to continue reviewing it.",
@@ -359,7 +487,7 @@ function startVersionExtractionPolling(jobId: string) {
         await refreshPosterList();
         toast.add({
           title: "Metadata extraction failed",
-          description: response.error || "Open the version panel for details.",
+          description: response.error || "Open the edit panel for details.",
           color: "error",
         });
 
@@ -427,21 +555,30 @@ async function deleteVersionDraft() {
   if (!draft) return;
 
   const jobId = draft.extractionJob?.id;
+  const rootPosterId = versionPoster.value?.rootPosterId;
   const wasExtracting = isVersionExtracting(draft);
+  const wasPollingThumbnail =
+    pollingVersionThumbnailJobId.value === draft.extractionJob?.id;
   deletingVersionDraft.value = true;
   versionPollingError.value = "";
   stopVersionExtractionPolling();
+  stopVersionThumbnailPolling();
 
   try {
     await $fetch(`/api/poster/${draft.id}`, { method: "DELETE" });
+
+    const dashboardPoster = posters.value.find(
+      (poster) => poster.rootPosterId === rootPosterId,
+    );
+    if (dashboardPoster) dashboardPoster.activeVersionDraft = null;
 
     deleteVersionModalOpen.value = false;
     versionModalOpen.value = false;
     versionPoster.value = null;
     await refreshPosterList();
     toast.add({
-      title: "Version draft deleted",
-      description: `Version ${draft.versionSequence} was deleted. Your published poster was not changed.`,
+      title: "Edits discarded",
+      description: `The draft for version ${draft.versionSequence} was deleted. Your published poster was not changed.`,
       color: "success",
     });
   } catch (error) {
@@ -449,15 +586,16 @@ async function deleteVersionDraft() {
       (error as { data?: { statusMessage?: string }; statusMessage?: string })
         ?.data?.statusMessage ||
       (error as { statusMessage?: string })?.statusMessage ||
-      "There was a problem deleting the version draft.";
+      "There was a problem discarding your edits.";
 
     toast.add({
-      title: "Could not delete version draft",
+      title: "Could not discard edits",
       description: message,
       color: "error",
     });
 
     if (wasExtracting && jobId) startVersionExtractionPolling(jobId);
+    if (wasPollingThumbnail && jobId) startVersionThumbnailPolling(jobId);
   } finally {
     deletingVersionDraft.value = false;
   }
@@ -466,7 +604,7 @@ async function deleteVersionDraft() {
 async function createVersion() {
   if (!versionPoster.value) return;
   if (versionFileMode.value === "upload" && !versionFiles.value[0]) {
-    versionError.value = "Choose a PDF or image for the new version.";
+    versionError.value = "Choose a replacement PDF or image.";
 
     return;
   }
@@ -481,6 +619,7 @@ async function createVersion() {
   creatingVersion.value = true;
   versionError.value = "";
   try {
+    const rootPosterId = versionPoster.value.rootPosterId;
     const body = new FormData();
     body.append("fileMode", versionFileMode.value);
     body.append("metadataMode", versionMetadataMode.value);
@@ -489,17 +628,23 @@ async function createVersion() {
     const response = await $fetch<{
       posterId: number;
       versionSequence: number;
+      imageUrl: string;
+      title: string;
+      description: string;
       extractionJobId?: string;
       extractionStatus?: string;
       reviewReady: boolean;
-    }>(`/api/poster/${versionPoster.value.rootPosterId}/versions`, {
+    }>(`/api/poster/${rootPosterId}/versions`, {
       method: "POST",
       body,
     });
 
-    versionPoster.value.activeVersionDraft = {
+    const activeVersionDraft: NonNullable<Poster["activeVersionDraft"]> = {
       id: response.posterId,
       versionSequence: response.versionSequence,
+      imageUrl: response.imageUrl,
+      title: response.title,
+      description: response.description,
       extractionJob: response.extractionJobId
         ? {
             id: response.extractionJobId,
@@ -508,14 +653,26 @@ async function createVersion() {
           }
         : null,
     };
+
+    const dashboardPoster = posters.value.find(
+      (poster) => poster.rootPosterId === rootPosterId,
+    );
+    if (dashboardPoster) {
+      dashboardPoster.activeVersionDraft = activeVersionDraft;
+      versionPoster.value = dashboardPoster;
+    } else if (versionPoster.value?.rootPosterId === rootPosterId) {
+      versionPoster.value.activeVersionDraft = activeVersionDraft;
+    }
+
     if (!response.reviewReady && response.extractionJobId) {
       startVersionExtractionPolling(response.extractionJobId);
     }
+    if (!response.imageUrl && response.extractionJobId) {
+      startVersionThumbnailPolling(response.extractionJobId);
+    }
   } catch (error) {
     versionError.value =
-      error instanceof Error
-        ? error.message
-        : "Could not create the new version.";
+      error instanceof Error ? error.message : "Could not prepare your edits.";
   } finally {
     creatingVersion.value = false;
   }
@@ -528,12 +685,26 @@ onMounted(() => {
   if (activeJob) {
     startVersionExtractionPolling(activeJob);
   }
+
+  const thumbnailJob =
+    posterAwaitingDraftThumbnail.value?.activeVersionDraft?.extractionJob?.id;
+  if (thumbnailJob) {
+    startVersionThumbnailPolling(thumbnailJob);
+  }
 });
 
-onBeforeUnmount(stopVersionExtractionPolling);
+onBeforeUnmount(() => {
+  stopVersionExtractionPolling();
+  stopVersionThumbnailPolling();
+});
 
 function openPoster(poster: Poster) {
-  if (poster.tombstone) return;
+  if (poster.tombstone) {
+    tombstonedPoster.value = poster;
+    tombstoneModalOpen.value = true;
+
+    return;
+  }
 
   if (poster.activeVersionDraft) {
     openVersionWorkflow(poster);
@@ -554,6 +725,13 @@ function openVersionWorkflow(poster: Poster) {
   }
 
   openVersionModal(poster);
+}
+
+function openDeleteVersionModal(poster: Poster) {
+  if (!isVersionReviewReady(poster.activeVersionDraft)) return;
+
+  versionPoster.value = poster;
+  deleteVersionModalOpen.value = true;
 }
 
 const regeneratingThumbnailIds = ref<number[]>([]);
@@ -694,6 +872,9 @@ async function savePublicationInfo() {
 }
 
 const getImage = (poster: Poster) => {
+  if (poster.activeVersionDraft?.imageUrl) {
+    return `/api/poster/${poster.activeVersionDraft.id}/thumbnail`;
+  }
   if (poster.status === "published") {
     return poster.imageUrl;
   }
@@ -701,13 +882,27 @@ const getImage = (poster: Poster) => {
 
   return `/api/poster/${poster.id}/thumbnail${bust ? `?t=${bust}` : ""}`;
 };
+
+const getCardTitle = (poster: Poster) =>
+  poster.activeVersionDraft?.title || poster.title;
+
+const CARD_TITLE_MAX_LENGTH = 80;
+const getCardDisplayTitle = (poster: Poster) => {
+  const title = getCardTitle(poster);
+
+  return title.length > CARD_TITLE_MAX_LENGTH
+    ? `${title.slice(0, CARD_TITLE_MAX_LENGTH).trimEnd()}…`
+    : title;
+};
+
+const getCardDescription = (poster: Poster) =>
+  poster.activeVersionDraft?.description ?? poster.description;
 </script>
 
 <template>
   <div class="mx-auto flex w-full max-w-screen-xl flex-col gap-6 px-6">
     <UPageHeader
       title="Dashboard"
-      description="Keep track of all your submitted posters."
       :links="[
         {
           label: 'Share a Poster',
@@ -716,21 +911,37 @@ const getImage = (poster: Poster) => {
           color: 'primary' as const,
         },
       ]"
-    />
+    >
+      <template #description>
+        <div class="flex w-full items-center justify-between gap-4">
+          <span>Keep track of all your submitted posters.</span>
+
+          <USwitch
+            v-if="tombstonedPosterCount > 0"
+            v-model="showTombstonedPosters"
+            :label="`Show tombstoned posters (${tombstonedPosterCount})`"
+            size="sm"
+          />
+        </div>
+      </template>
+    </UPageHeader>
 
     <UPageList class="max-md:flex max-md:flex-col max-md:gap-4">
       <UPageCard
-        v-for="(poster, index) in posters"
+        v-for="(poster, index) in visiblePosters"
         :key="poster.rootPosterId ?? index + 1"
         variant="ghost"
         class="group h-50 overflow-hidden rounded-none border-t border-b border-gray-100 transition-all duration-300 max-md:h-auto max-md:rounded-xl max-md:border max-md:bg-white max-md:shadow-sm dark:max-md:border-gray-800 dark:max-md:bg-gray-950"
         :class="
           poster.tombstone
-            ? 'cursor-not-allowed opacity-70'
+            ? 'cursor-pointer opacity-70 hover:opacity-100'
             : 'cursor-pointer max-md:hover:shadow-md'
         "
-        :aria-disabled="poster.tombstone"
+        :aria-haspopup="poster.tombstone ? 'dialog' : undefined"
+        :tabindex="poster.tombstone ? 0 : undefined"
         @click="openPoster(poster)"
+        @keydown.enter="poster.tombstone && openPoster(poster)"
+        @keydown.space.prevent="poster.tombstone && openPoster(poster)"
       >
         <div
           class="flex h-full gap-8 max-md:h-auto max-md:flex-col max-md:gap-0"
@@ -743,7 +954,7 @@ const getImage = (poster: Poster) => {
                 getImage(poster) ||
                 `https://api.dicebear.com/9.x/shapes/svg?seed=${poster.id}`
               "
-              :alt="poster.title"
+              :alt="getCardTitle(poster)"
               class="max-h-[150px] w-full object-contain p-2 transition-transform duration-300 max-md:h-full max-md:max-h-none max-md:p-3"
               :class="{ 'group-hover:scale-105': !poster.tombstone }"
             />
@@ -753,8 +964,11 @@ const getImage = (poster: Poster) => {
             class="flex h-full w-full min-w-0 flex-col justify-between py-1 max-md:h-auto max-md:gap-3 max-md:p-4 max-md:py-4"
           >
             <div class="flex flex-col gap-2">
-              <h3 class="line-clamp-2 text-lg font-semibold">
-                {{ poster.title || "No title available" }}
+              <h3
+                class="line-clamp-2 max-h-14 overflow-hidden text-lg font-semibold break-words"
+                :title="getCardTitle(poster)"
+              >
+                {{ getCardDisplayTitle(poster) || "No title available" }}
               </h3>
 
               <p v-if="poster.versionCount > 1" class="text-muted text-xs">
@@ -780,8 +994,7 @@ const getImage = (poster: Poster) => {
                   icon="i-lucide-loader-circle"
                   class="w-fit"
                 >
-                  Version {{ poster.activeVersionDraft?.versionSequence }}
-                  extraction in progress
+                  Preparing edits
                 </UBadge>
 
                 <UBadge
@@ -794,8 +1007,7 @@ const getImage = (poster: Poster) => {
                   icon="i-lucide-circle-alert"
                   class="w-fit"
                 >
-                  Version {{ poster.activeVersionDraft?.versionSequence }}
-                  extraction failed
+                  Could not prepare edits
                 </UBadge>
 
                 <UBadge
@@ -806,8 +1018,7 @@ const getImage = (poster: Poster) => {
                   icon="i-lucide-circle-check"
                   class="w-fit"
                 >
-                  Version {{ poster.activeVersionDraft?.versionSequence }} ready
-                  to review
+                  Edits ready to review
                 </UBadge>
               </div>
 
@@ -818,11 +1029,11 @@ const getImage = (poster: Poster) => {
                     expandedDescriptions.has(poster.id) ? '' : 'line-clamp-2',
                   ]"
                 >
-                  {{ poster.description || "No description available" }}
+                  {{ getCardDescription(poster) || "No description available" }}
                 </p>
 
                 <button
-                  v-if="(poster.description?.length ?? 0) > 100"
+                  v-if="getCardDescription(poster).length > 100"
                   class="text-primary w-fit text-left text-xs font-medium md:hidden"
                   @click.stop="toggleDescription(poster.id)"
                 >
@@ -889,6 +1100,25 @@ const getImage = (poster: Poster) => {
                       @click="openVersionWorkflow(poster)"
                     />
                   </span>
+                </UTooltip>
+
+                <UTooltip
+                  v-if="
+                    poster.status === 'published' &&
+                    poster.activeVersionDraft &&
+                    isVersionReviewReady(poster.activeVersionDraft) &&
+                    !poster.tombstone
+                  "
+                  text="Delete unpublished draft version"
+                >
+                  <UButton
+                    color="error"
+                    variant="ghost"
+                    icon="heroicons:trash"
+                    size="xs"
+                    aria-label="Delete unpublished draft version"
+                    @click.stop="openDeleteVersionModal(poster)"
+                  />
                 </UTooltip>
 
                 <UButton
@@ -983,8 +1213,29 @@ const getImage = (poster: Poster) => {
       </UPageCard>
     </UPageList>
 
-    <div v-if="posters.length === 0" class="py-12 text-center">
+    <div v-if="visiblePosters.length === 0" class="py-12 text-center">
+      <div
+        v-if="posters.length > 0"
+        class="mx-auto flex max-w-md flex-col items-center gap-3"
+      >
+        <Icon name="i-lucide-archive-x" class="text-muted h-12 w-12" />
+
+        <h3 class="text-lg font-medium">Tombstoned posters are hidden</h3>
+
+        <p class="text-muted text-sm">
+          Turn on “Show tombstoned posters” to include them in your dashboard.
+        </p>
+
+        <UButton
+          label="Show tombstoned posters"
+          color="neutral"
+          variant="subtle"
+          @click="showTombstonedPosters = true"
+        />
+      </div>
+
       <NuxtLink
+        v-else
         to="/share/new"
         class="group inline-block rounded-2xl px-8 py-6 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800/50"
       >
@@ -1012,15 +1263,11 @@ const getImage = (poster: Poster) => {
     <!-- Delete draft modal -->
     <USlideover
       v-model:open="versionModalOpen"
-      :title="
-        versionPanelState === 'setup'
-          ? 'Publish a New Version'
-          : `Version ${currentVersionDraft?.versionSequence ?? ''}`
-      "
+      title="Edit Published Poster"
       :description="
         versionPanelState === 'setup'
-          ? 'Choose the file and metadata for the next version.'
-          : `New version of ${versionPoster?.title ?? 'your poster'}`
+          ? 'Select what you would like to change.'
+          : `Editing ${versionPoster?.title ?? 'your poster'}`
       "
       side="right"
       class="w-full max-w-2xl"
@@ -1034,17 +1281,11 @@ const getImage = (poster: Poster) => {
         >
           <div class="space-y-5">
             <p class="text-muted text-sm">
-              Create the next version of
+              Select what you would like to change for
               <span class="text-highlighted font-medium">{{
                 versionPoster?.title
               }}</span
-              >. You'll review all metadata before publishing.
-            </p>
-
-            <p class="text-muted text-sm">
-              Choose the option that matches what changed. If neither the poster
-              file nor its metadata needs updating, you do not need to publish a
-              new version.
+              >. You will review your changes before publishing.
             </p>
 
             <UFormField label="Poster file">
@@ -1072,7 +1313,7 @@ const getImage = (poster: Poster) => {
               v-if="versionError"
               color="error"
               variant="soft"
-              title="Could not create version"
+              title="Could not prepare edits"
               :description="versionError"
             />
           </div>
@@ -1081,9 +1322,9 @@ const getImage = (poster: Poster) => {
             <UAlert
               color="primary"
               variant="soft"
-              icon="i-lucide-git-branch"
-              :title="`You’re creating version ${(versionPoster?.versionSequence ?? 0) + 1}`"
-              description="Version numbers are assigned automatically and increase by one with each published version."
+              icon="i-lucide-info"
+              title="How editing a published poster works"
+              description="Published records cannot be modified after publication. Editing a published poster creates a new publication on top of the existing one, which appears as a new version. Only create a new version when the poster file has changed or its metadata needs to be corrected or updated."
             />
           </div>
         </div>
@@ -1121,7 +1362,7 @@ const getImage = (poster: Poster) => {
             color="warning"
             variant="soft"
             title="Status temporarily unavailable"
-            :description="`${versionPollingError} We’ll keep trying automatically.`"
+            :description="`${versionPollingError} We'll keep trying automatically.`"
           />
 
           <p class="text-muted text-sm">
@@ -1136,13 +1377,13 @@ const getImage = (poster: Poster) => {
             color="success"
             variant="soft"
             icon="i-lucide-circle-check"
-            :title="`Version ${currentVersionDraft?.versionSequence} is ready to review`"
-            description="Metadata preparation is complete. Continue to review and edit the extracted metadata before publishing."
+            title="Your edits are ready to review"
+            description="Your metadata is ready. Continue to review and edit it before publishing your changes."
           />
 
           <p class="text-muted text-sm">
             Your published poster remains unchanged until you finish reviewing
-            this draft and publish it to Zenodo.
+            and publish your edits.
           </p>
         </div>
 
@@ -1160,7 +1401,7 @@ const getImage = (poster: Poster) => {
 
           <p class="text-muted text-sm">
             The published poster has not been changed. Retrying uses the same
-            version draft and stored poster file.
+            editable draft and stored poster file.
           </p>
 
           <UAlert
@@ -1191,29 +1432,28 @@ const getImage = (poster: Poster) => {
             :loading="creatingVersion"
             @click="createVersion"
           >
-            Create Version Draft
+            Continue
           </UButton>
         </div>
 
         <div
-          v-else
+          v-else-if="
+            versionPanelState === 'ready' || versionPanelState === 'failed'
+          "
           class="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
         >
           <UButton
+            v-if="versionPanelState === 'ready'"
             color="error"
             variant="soft"
             icon="i-lucide-trash-2"
             :disabled="retryingVersionExtraction"
             @click="deleteVersionModalOpen = true"
           >
-            Delete Version Draft
+            Discard Edits
           </UButton>
 
           <div class="flex flex-wrap justify-end gap-3">
-            <UButton variant="outline" @click="versionModalOpen = false">
-              Close
-            </UButton>
-
             <UButton
               v-if="versionPanelState === 'ready'"
               color="primary"
@@ -1239,15 +1479,33 @@ const getImage = (poster: Poster) => {
     </USlideover>
 
     <UModal
+      v-model:open="tombstoneModalOpen"
+      title="Why this poster was tombstoned"
+      :description="tombstonedPoster?.title || 'Tombstoned poster'"
+    >
+      <template #body>
+        <UAlert
+          color="error"
+          variant="soft"
+          icon="i-lucide-archive-x"
+          title="Reason"
+          :description="
+            tombstonedPoster?.tombedReason?.trim() || 'No reason was provided.'
+          "
+        />
+      </template>
+    </UModal>
+
+    <UModal
       v-model:open="deleteVersionModalOpen"
-      title="Delete Version Draft?"
+      title="Discard Edits?"
       :dismissible="!deletingVersionDraft"
       :close="!deletingVersionDraft"
     >
       <template #body>
         <div class="space-y-3 text-sm">
           <p>
-            Delete version
+            Discard the draft changes for version
             <span class="font-medium">{{
               currentVersionDraft?.versionSequence
             }}</span>
@@ -1259,10 +1517,9 @@ const getImage = (poster: Poster) => {
           </p>
 
           <p class="text-muted">
-            This removes the version draft, its stored poster file, metadata,
-            and extraction progress. Any linked unpublished Zenodo draft will
-            also be discarded. The published poster and its earlier versions
-            will not be changed. This cannot be undone.
+            This removes the editable draft, its stored poster file and
+            metadata. The published poster and its earlier versions will not be
+            changed. This cannot be undone.
           </p>
         </div>
       </template>
@@ -1282,7 +1539,7 @@ const getImage = (poster: Poster) => {
             :loading="deletingVersionDraft"
             @click="deleteVersionDraft"
           >
-            Delete Version Draft
+            Discard Edits
           </UButton>
         </div>
       </template>

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -1443,7 +1443,9 @@ const getCardDescription = (poster: Poster) =>
           class="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
         >
           <UButton
-            v-if="versionPanelState === 'ready'"
+            v-if="
+              versionPanelState === 'ready' || versionPanelState === 'failed'
+            "
             color="error"
             variant="soft"
             icon="i-lucide-trash-2"

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -22,7 +22,9 @@ type Poster = {
   title: string;
   description: string;
   imageUrl: string;
+  automated: boolean;
   status: "draft" | "downloaded" | "published";
+  versionSequence: number;
   publishedAt: Date | null;
   created: Date;
   updated: Date;
@@ -31,9 +33,25 @@ type Poster = {
     publicationYear: number | null;
     doi: string | null;
     license: string | null;
+    version: string | null;
   };
   extractionJob?: {
+    id?: string;
     status: string;
+    completed?: boolean;
+    error?: string | null;
+  } | null;
+  rootPosterId: number;
+  versionCount: number;
+  activeVersionDraft?: {
+    id: number;
+    versionSequence: number;
+    extractionJob?: {
+      id?: string;
+      status: string;
+      completed?: boolean;
+      error?: string | null;
+    } | null;
   } | null;
 };
 
@@ -58,6 +76,455 @@ const modalPublisher = ref("");
 const isSaving = ref(false);
 const doiError = ref("");
 const toast = useToast();
+
+const versionModalOpen = ref(false);
+const versionPoster = ref<Poster | null>(null);
+const versionFileMode = ref<"reuse" | "upload">("reuse");
+const versionMetadataMode = ref<"copy" | "extract">("copy");
+const versionFiles = ref<File[]>([]);
+const creatingVersion = ref(false);
+const versionError = ref("");
+const versionPollingError = ref("");
+const retryingVersionExtraction = ref(false);
+const deleteVersionModalOpen = ref(false);
+const deletingVersionDraft = ref(false);
+const pollingVersionJobId = ref<string | null>(null);
+let versionPollTimer: ReturnType<typeof setTimeout> | undefined;
+let versionPollGeneration = 0;
+
+const versionFileOptions = [
+  {
+    label: "Reuse the current poster file",
+    description:
+      "For a new release where the poster is unchanged but its supplemental metadata need to be updated.",
+    value: "reuse",
+  },
+  {
+    label: "Upload a new PDF or image",
+    description:
+      "For a revised poster with changes to its content, design, or file.",
+    value: "upload",
+  },
+];
+const versionMetadataOptions = [
+  {
+    label: "Start with the existing metadata",
+    description:
+      "Best for smaller poster revisions. The copied metadata remains editable during review.",
+    value: "copy",
+  },
+  {
+    label: "Extract metadata from the new poster file",
+    description:
+      "Best when the poster content changed enough that the existing metadata may be outdated.",
+    value: "extract",
+  },
+];
+
+function isVersionExtracting(draft: Poster["activeVersionDraft"]): boolean {
+  return (
+    draft?.extractionJob?.status === "pending-extraction" ||
+    draft?.extractionJob?.status === "processing"
+  );
+}
+
+function isVersionExtractionFailed(
+  draft: Poster["activeVersionDraft"],
+): boolean {
+  return draft?.extractionJob?.status === "failed";
+}
+
+function isVersionReviewReady(draft: Poster["activeVersionDraft"]): boolean {
+  return Boolean(
+    draft &&
+    (!draft.extractionJob ||
+      draft.extractionJob.completed ||
+      draft.extractionJob.status === "completed"),
+  );
+}
+
+const currentVersionDraft = computed(
+  () => versionPoster.value?.activeVersionDraft ?? null,
+);
+const versionPanelState = computed<"setup" | "extracting" | "ready" | "failed">(
+  () => {
+    if (!currentVersionDraft.value) return "setup";
+    if (isVersionExtractionFailed(currentVersionDraft.value)) return "failed";
+    if (isVersionExtracting(currentVersionDraft.value)) return "extracting";
+
+    return "ready";
+  },
+);
+const versionExtractionStatus = computed(() => {
+  const status = currentVersionDraft.value?.extractionJob?.status;
+  if (status === "pending-extraction") {
+    return {
+      title: "Waiting for extraction to start",
+      description:
+        "The job is saved in the queue. The extraction service will claim it automatically.",
+    };
+  }
+  if (status === "processing") {
+    return {
+      title: "Extracting poster metadata",
+      description:
+        "The extraction service is analyzing the poster and saving the fields you’ll review and edit next.",
+    };
+  }
+
+  return {
+    title: "Preparing your version",
+    description: "The version draft is being prepared.",
+  };
+});
+
+const extractingVersionPoster = computed(() =>
+  posters.value.find((poster) =>
+    isVersionExtracting(poster.activeVersionDraft),
+  ),
+);
+
+function versionActionDisabled(poster: Poster) {
+  return Boolean(
+    extractingVersionPoster.value &&
+    !isVersionExtracting(poster.activeVersionDraft) &&
+    extractingVersionPoster.value.rootPosterId !== poster.rootPosterId,
+  );
+}
+
+function versionActionLabel(poster: Poster) {
+  if (isVersionExtracting(poster.activeVersionDraft)) {
+    return "View extraction progress";
+  }
+  if (isVersionExtractionFailed(poster.activeVersionDraft)) {
+    return "View extraction error";
+  }
+  if (poster.activeVersionDraft) return "Review new version";
+
+  return "Publish new version";
+}
+
+function versionActionTooltip(poster: Poster) {
+  if (isVersionExtracting(poster.activeVersionDraft)) {
+    return "Open the version panel to view metadata extraction progress.";
+  }
+  if (isVersionExtractionFailed(poster.activeVersionDraft)) {
+    return "Open the version panel to view the extraction error.";
+  }
+  if (
+    extractingVersionPoster.value &&
+    extractingVersionPoster.value.rootPosterId !== poster.rootPosterId
+  ) {
+    return `Wait for metadata extraction on “${extractingVersionPoster.value.title}” to finish.`;
+  }
+
+  return poster.activeVersionDraft
+    ? "Review the version draft before publishing it."
+    : "Create a new version of this poster.";
+}
+
+function displayedVersion(poster: Poster) {
+  if (poster.status !== "published") return null;
+  if (!poster.automated) return String(poster.versionSequence);
+
+  return poster.posterMetadata.version?.trim() || null;
+}
+
+watch(versionFileMode, (mode) => {
+  versionError.value = "";
+  if (mode === "reuse") {
+    versionMetadataMode.value = "copy";
+    versionFiles.value = [];
+  }
+});
+
+function openVersionModal(poster: Poster) {
+  versionPoster.value = poster;
+  if (!poster.activeVersionDraft) {
+    versionFileMode.value = "reuse";
+    versionMetadataMode.value = "copy";
+    versionFiles.value = [];
+  }
+  versionError.value = "";
+  versionPollingError.value = "";
+  versionModalOpen.value = true;
+
+  const activeJob = poster.activeVersionDraft?.extractionJob?.id;
+  if (activeJob && isVersionExtracting(poster.activeVersionDraft)) {
+    startVersionExtractionPolling(activeJob);
+  }
+}
+
+function updateLocalVersionJob(
+  posterId: number | undefined,
+  status: string,
+  completed: boolean,
+  error?: string | null,
+) {
+  if (!posterId) return;
+
+  for (const poster of posters.value) {
+    if (poster.activeVersionDraft?.id === posterId) {
+      poster.activeVersionDraft.extractionJob = {
+        ...poster.activeVersionDraft.extractionJob,
+        status,
+        completed,
+        error,
+      };
+
+      return;
+    }
+  }
+}
+
+async function refreshPosterList() {
+  const openRootId = versionPoster.value?.rootPosterId;
+  await refresh();
+  posters.value = (data.value ?? []) as unknown as Poster[];
+  if (openRootId) {
+    versionPoster.value =
+      posters.value.find((poster) => poster.rootPosterId === openRootId) ??
+      null;
+  }
+}
+
+function stopVersionExtractionPolling() {
+  versionPollGeneration += 1;
+  pollingVersionJobId.value = null;
+  if (versionPollTimer) {
+    clearTimeout(versionPollTimer);
+    versionPollTimer = undefined;
+  }
+}
+
+function startVersionExtractionPolling(jobId: string) {
+  if (pollingVersionJobId.value === jobId) return;
+
+  stopVersionExtractionPolling();
+  pollingVersionJobId.value = jobId;
+  const generation = versionPollGeneration;
+
+  const checkStatus = async () => {
+    if (generation !== versionPollGeneration) return;
+
+    try {
+      const response = await $fetch<{
+        completed: boolean;
+        status: string;
+        posterId?: number;
+        error?: string | null;
+      }>(`/api/poster/job/${jobId}`);
+
+      if (generation !== versionPollGeneration) return;
+
+      versionPollingError.value = "";
+      updateLocalVersionJob(
+        response.posterId,
+        response.status,
+        response.completed,
+        response.error,
+      );
+
+      if (response.completed && response.status === "completed") {
+        const keepPanelOpen =
+          versionModalOpen.value &&
+          currentVersionDraft.value?.extractionJob?.id === jobId;
+        pollingVersionJobId.value = null;
+        await refreshPosterList();
+        if (!keepPanelOpen && response.posterId) {
+          await navigateTo(`/share/${response.posterId}`);
+        }
+
+        return;
+      }
+
+      if (response.status === "failed") {
+        pollingVersionJobId.value = null;
+        await refreshPosterList();
+        toast.add({
+          title: "Metadata extraction failed",
+          description: response.error || "Open the version panel for details.",
+          color: "error",
+        });
+
+        return;
+      }
+    } catch (error) {
+      if (generation !== versionPollGeneration) return;
+
+      versionPollingError.value =
+        error instanceof Error
+          ? `Could not refresh the extraction status: ${error.message}`
+          : "Could not refresh the extraction status. Retrying…";
+    }
+
+    if (generation === versionPollGeneration) {
+      versionPollTimer = setTimeout(checkStatus, 3000);
+    }
+  };
+
+  void checkStatus();
+}
+
+async function reviewVersionDraft() {
+  const draftId = currentVersionDraft.value?.id;
+  if (draftId) {
+    versionModalOpen.value = false;
+    await navigateTo(`/share/${draftId}`);
+  }
+}
+
+async function retryVersionExtraction() {
+  const jobId = currentVersionDraft.value?.extractionJob?.id;
+  const posterId = currentVersionDraft.value?.id;
+  if (!jobId || !posterId) return;
+
+  retryingVersionExtraction.value = true;
+  versionPollingError.value = "";
+
+  try {
+    const response = await $fetch<{
+      status: string;
+      completed: boolean;
+      error?: string | null;
+    }>(`/api/poster/job/${jobId}/retry`, { method: "POST" });
+
+    updateLocalVersionJob(
+      posterId,
+      response.status,
+      response.completed,
+      response.error,
+    );
+    startVersionExtractionPolling(jobId);
+  } catch (error) {
+    versionPollingError.value =
+      error instanceof Error
+        ? error.message
+        : "Could not restart metadata extraction.";
+  } finally {
+    retryingVersionExtraction.value = false;
+  }
+}
+
+async function deleteVersionDraft() {
+  const draft = currentVersionDraft.value;
+  if (!draft) return;
+
+  const jobId = draft.extractionJob?.id;
+  const wasExtracting = isVersionExtracting(draft);
+  deletingVersionDraft.value = true;
+  versionPollingError.value = "";
+  stopVersionExtractionPolling();
+
+  try {
+    await $fetch(`/api/poster/${draft.id}`, { method: "DELETE" });
+
+    deleteVersionModalOpen.value = false;
+    versionModalOpen.value = false;
+    versionPoster.value = null;
+    await refreshPosterList();
+    toast.add({
+      title: "Version draft deleted",
+      description: `Version ${draft.versionSequence} was deleted. Your published poster was not changed.`,
+      color: "success",
+    });
+  } catch (error) {
+    const message =
+      (error as { data?: { statusMessage?: string }; statusMessage?: string })
+        ?.data?.statusMessage ||
+      (error as { statusMessage?: string })?.statusMessage ||
+      "There was a problem deleting the version draft.";
+
+    toast.add({
+      title: "Could not delete version draft",
+      description: message,
+      color: "error",
+    });
+
+    if (wasExtracting && jobId) startVersionExtractionPolling(jobId);
+  } finally {
+    deletingVersionDraft.value = false;
+  }
+}
+
+async function createVersion() {
+  if (!versionPoster.value) return;
+  if (versionFileMode.value === "upload" && !versionFiles.value[0]) {
+    versionError.value = "Choose a PDF or image for the new version.";
+
+    return;
+  }
+
+  const file = versionFiles.value[0];
+  if (file && file.size > 10 * 1024 * 1024) {
+    versionError.value = "File must be 10MB or smaller.";
+
+    return;
+  }
+
+  creatingVersion.value = true;
+  versionError.value = "";
+  try {
+    const body = new FormData();
+    body.append("fileMode", versionFileMode.value);
+    body.append("metadataMode", versionMetadataMode.value);
+    if (file) body.append("file", file);
+
+    const response = await $fetch<{
+      posterId: number;
+      versionSequence: number;
+      extractionJobId?: string;
+      extractionStatus?: string;
+      reviewReady: boolean;
+    }>(`/api/poster/${versionPoster.value.rootPosterId}/versions`, {
+      method: "POST",
+      body,
+    });
+
+    versionPoster.value.activeVersionDraft = {
+      id: response.posterId,
+      versionSequence: response.versionSequence,
+      extractionJob: response.extractionJobId
+        ? {
+            id: response.extractionJobId,
+            status: response.extractionStatus ?? "pending-extraction",
+            completed: response.reviewReady,
+          }
+        : null,
+    };
+    if (!response.reviewReady && response.extractionJobId) {
+      startVersionExtractionPolling(response.extractionJobId);
+    }
+  } catch (error) {
+    versionError.value =
+      error instanceof Error
+        ? error.message
+        : "Could not create the new version.";
+  } finally {
+    creatingVersion.value = false;
+  }
+}
+
+onMounted(() => {
+  const activeJob =
+    extractingVersionPoster.value?.activeVersionDraft?.extractionJob?.id;
+
+  if (activeJob) {
+    startVersionExtractionPolling(activeJob);
+  }
+});
+
+onBeforeUnmount(stopVersionExtractionPolling);
+
+function openPoster(poster: Poster) {
+  if (poster.activeVersionDraft) {
+    openVersionModal(poster);
+  } else if (poster.status === "published") {
+    void navigateTo(`/discover/${poster.rootPosterId}`);
+  } else {
+    void navigateTo(`/share/${poster.id}`);
+  }
+}
 
 const regeneratingThumbnailIds = ref<number[]>([]);
 const thumbnailCacheBust = reactive<Record<number, number>>({});
@@ -224,10 +691,10 @@ const getImage = (poster: Poster) => {
     <UPageList class="max-md:flex max-md:flex-col max-md:gap-4">
       <UPageCard
         v-for="(poster, index) in posters"
-        :key="index + 1"
+        :key="poster.rootPosterId ?? index + 1"
         variant="ghost"
         class="group h-50 cursor-pointer overflow-hidden rounded-none border-t border-b border-gray-100 transition-all duration-300 max-md:h-auto max-md:rounded-xl max-md:border max-md:bg-white max-md:shadow-sm max-md:hover:shadow-md dark:max-md:border-gray-800 dark:max-md:bg-gray-950"
-        @click="navigateTo(`/share/${poster.id}`)"
+        @click="openPoster(poster)"
       >
         <div
           class="flex h-full gap-8 max-md:h-auto max-md:flex-col max-md:gap-0"
@@ -252,6 +719,60 @@ const getImage = (poster: Poster) => {
               <h3 class="line-clamp-2 text-lg font-semibold">
                 {{ poster.title || "No title available" }}
               </h3>
+
+              <p v-if="poster.versionCount > 1" class="text-muted text-xs">
+                {{ poster.versionCount }} published versions
+              </p>
+
+              <div class="flex flex-wrap items-center gap-2">
+                <UBadge
+                  v-if="displayedVersion(poster)"
+                  color="neutral"
+                  variant="soft"
+                  size="sm"
+                  class="w-fit"
+                >
+                  Version {{ displayedVersion(poster) }}
+                </UBadge>
+
+                <UBadge
+                  v-if="isVersionExtracting(poster.activeVersionDraft)"
+                  color="info"
+                  variant="soft"
+                  size="sm"
+                  icon="i-lucide-loader-circle"
+                  class="w-fit"
+                >
+                  Version {{ poster.activeVersionDraft?.versionSequence }}
+                  extraction in progress
+                </UBadge>
+
+                <UBadge
+                  v-else-if="
+                    isVersionExtractionFailed(poster.activeVersionDraft)
+                  "
+                  color="error"
+                  variant="soft"
+                  size="sm"
+                  icon="i-lucide-circle-alert"
+                  class="w-fit"
+                >
+                  Version {{ poster.activeVersionDraft?.versionSequence }}
+                  extraction failed
+                </UBadge>
+
+                <UBadge
+                  v-else-if="isVersionReviewReady(poster.activeVersionDraft)"
+                  color="success"
+                  variant="soft"
+                  size="sm"
+                  icon="i-lucide-circle-check"
+                  class="w-fit"
+                >
+                  Version {{ poster.activeVersionDraft?.versionSequence }} ready
+                  to review
+                </UBadge>
+              </div>
 
               <div class="flex flex-col gap-1">
                 <p
@@ -304,6 +825,31 @@ const getImage = (poster: Poster) => {
               </div>
 
               <div class="flex items-center gap-2 max-md:flex-wrap">
+                <UTooltip
+                  v-if="poster.status === 'published' && !poster.automated"
+                  :text="versionActionTooltip(poster)"
+                >
+                  <span class="inline-flex" @click.stop>
+                    <UButton
+                      color="primary"
+                      variant="subtle"
+                      :label="versionActionLabel(poster)"
+                      :icon="
+                        isVersionExtracting(poster.activeVersionDraft)
+                          ? 'i-lucide-activity'
+                          : isVersionExtractionFailed(poster.activeVersionDraft)
+                            ? 'i-lucide-circle-alert'
+                            : poster.activeVersionDraft
+                              ? 'heroicons:pencil-square'
+                              : 'heroicons:arrow-up-tray'
+                      "
+                      size="xs"
+                      :disabled="versionActionDisabled(poster)"
+                      @click="openVersionModal(poster)"
+                    />
+                  </span>
+                </UTooltip>
+
                 <UButton
                   v-if="poster.status === 'downloaded'"
                   color="secondary"
@@ -404,6 +950,284 @@ const getImage = (poster: Poster) => {
     </div>
 
     <!-- Delete draft modal -->
+    <USlideover
+      v-model:open="versionModalOpen"
+      :title="
+        versionPanelState === 'setup'
+          ? 'Publish a New Version'
+          : `Version ${currentVersionDraft?.versionSequence ?? ''}`
+      "
+      :description="
+        versionPanelState === 'setup'
+          ? 'Choose the file and metadata for the next version.'
+          : `New version of ${versionPoster?.title ?? 'your poster'}`
+      "
+      side="right"
+      class="w-full max-w-2xl"
+      :dismissible="!creatingVersion && !deletingVersionDraft"
+      :close="!creatingVersion && !deletingVersionDraft"
+    >
+      <template #body>
+        <div
+          v-if="versionPanelState === 'setup'"
+          class="flex min-h-full flex-col"
+        >
+          <div class="space-y-5">
+            <p class="text-muted text-sm">
+              Create the next version of
+              <span class="text-highlighted font-medium">{{
+                versionPoster?.title
+              }}</span
+              >. You'll review all metadata before publishing.
+            </p>
+
+            <p class="text-muted text-sm">
+              Choose the option that matches what changed. If neither the poster
+              file nor its metadata needs updating, you do not need to publish a
+              new version.
+            </p>
+
+            <UFormField label="Poster file">
+              <URadioGroup
+                v-model="versionFileMode"
+                :items="versionFileOptions"
+              />
+            </UFormField>
+
+            <UiFileUpload
+              v-if="versionFileMode === 'upload'"
+              @on-change="versionFiles = $event"
+            >
+              <UiFileUploadGrid />
+            </UiFileUpload>
+
+            <UFormField v-if="versionFileMode === 'upload'" label="Metadata">
+              <URadioGroup
+                v-model="versionMetadataMode"
+                :items="versionMetadataOptions"
+              />
+            </UFormField>
+
+            <UAlert
+              v-if="versionError"
+              color="error"
+              variant="soft"
+              title="Could not create version"
+              :description="versionError"
+            />
+          </div>
+
+          <div class="bg-default sticky bottom-0 z-10 mt-auto pt-5">
+            <UAlert
+              color="primary"
+              variant="soft"
+              icon="i-lucide-git-branch"
+              :title="`You’re creating version ${(versionPoster?.versionSequence ?? 0) + 1}`"
+              description="Version numbers are assigned automatically and increase by one with each published version."
+            />
+          </div>
+        </div>
+
+        <div v-else-if="versionPanelState === 'extracting'" class="space-y-6">
+          <div class="space-y-2">
+            <div class="flex items-center justify-between gap-3">
+              <h3 class="font-medium">
+                {{ versionExtractionStatus.title }}
+              </h3>
+
+              <UBadge color="info" variant="soft">
+                Version {{ currentVersionDraft?.versionSequence }}
+              </UBadge>
+            </div>
+
+            <p class="text-muted text-sm">
+              {{ versionExtractionStatus.description }}
+            </p>
+          </div>
+
+          <UProgress color="primary" size="md" animation="carousel" />
+
+          <p class="text-muted text-sm">
+            {{
+              currentVersionDraft?.extractionJob?.status ===
+              "pending-extraction"
+                ? "This status will change automatically when the extraction service claims the job."
+                : "This status will change to ready for review after the extracted fields have been saved."
+            }}
+          </p>
+
+          <UAlert
+            v-if="versionPollingError"
+            color="warning"
+            variant="soft"
+            title="Status temporarily unavailable"
+            :description="`${versionPollingError} We’ll keep trying automatically.`"
+          />
+
+          <p class="text-muted text-sm">
+            You can close this panel, refresh the dashboard, or leave this page.
+            Extraction will continue, and this panel will show the latest status
+            when you return.
+          </p>
+        </div>
+
+        <div v-else-if="versionPanelState === 'ready'" class="space-y-5">
+          <UAlert
+            color="success"
+            variant="soft"
+            icon="i-lucide-circle-check"
+            :title="`Version ${currentVersionDraft?.versionSequence} is ready to review`"
+            description="Metadata preparation is complete. Continue to review and edit the extracted metadata before publishing."
+          />
+
+          <p class="text-muted text-sm">
+            Your published poster remains unchanged until you finish reviewing
+            this draft and publish it to Zenodo.
+          </p>
+        </div>
+
+        <div v-else class="space-y-5">
+          <UAlert
+            color="error"
+            variant="soft"
+            icon="i-lucide-circle-alert"
+            title="Metadata extraction failed"
+            :description="
+              currentVersionDraft?.extractionJob?.error ||
+              'The extraction service could not process this poster file.'
+            "
+          />
+
+          <p class="text-muted text-sm">
+            The published poster has not been changed. Retrying uses the same
+            version draft and stored poster file.
+          </p>
+
+          <UAlert
+            v-if="versionPollingError"
+            color="warning"
+            variant="soft"
+            title="Could not retry extraction"
+            :description="versionPollingError"
+          />
+        </div>
+      </template>
+
+      <template #footer>
+        <div
+          v-if="versionPanelState === 'setup'"
+          class="flex w-full justify-end gap-3"
+        >
+          <UButton
+            variant="outline"
+            :disabled="creatingVersion"
+            @click="versionModalOpen = false"
+          >
+            Cancel
+          </UButton>
+
+          <UButton
+            color="primary"
+            :loading="creatingVersion"
+            @click="createVersion"
+          >
+            Create Version Draft
+          </UButton>
+        </div>
+
+        <div
+          v-else
+          class="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <UButton
+            color="error"
+            variant="soft"
+            icon="i-lucide-trash-2"
+            :disabled="retryingVersionExtraction"
+            @click="deleteVersionModalOpen = true"
+          >
+            Delete Version Draft
+          </UButton>
+
+          <div class="flex flex-wrap justify-end gap-3">
+            <UButton variant="outline" @click="versionModalOpen = false">
+              Close
+            </UButton>
+
+            <UButton
+              v-if="versionPanelState === 'ready'"
+              color="primary"
+              icon="i-lucide-arrow-right"
+              trailing
+              @click="reviewVersionDraft"
+            >
+              Review Metadata
+            </UButton>
+
+            <UButton
+              v-else-if="versionPanelState === 'failed'"
+              color="primary"
+              icon="i-lucide-refresh-cw"
+              :loading="retryingVersionExtraction"
+              @click="retryVersionExtraction"
+            >
+              Retry Extraction
+            </UButton>
+          </div>
+        </div>
+      </template>
+    </USlideover>
+
+    <UModal
+      v-model:open="deleteVersionModalOpen"
+      title="Delete Version Draft?"
+      :dismissible="!deletingVersionDraft"
+      :close="!deletingVersionDraft"
+    >
+      <template #body>
+        <div class="space-y-3 text-sm">
+          <p>
+            Delete version
+            <span class="font-medium">{{
+              currentVersionDraft?.versionSequence
+            }}</span>
+            of
+            <span class="font-medium">{{
+              versionPoster?.title || "this poster"
+            }}</span
+            >?
+          </p>
+
+          <p class="text-muted">
+            This removes the version draft, its stored poster file, metadata,
+            and extraction progress. Any linked unpublished Zenodo draft will
+            also be discarded. The published poster and its earlier versions
+            will not be changed. This cannot be undone.
+          </p>
+        </div>
+      </template>
+
+      <template #footer>
+        <div class="flex w-full justify-end gap-3">
+          <UButton
+            variant="outline"
+            :disabled="deletingVersionDraft"
+            @click="deleteVersionModalOpen = false"
+          >
+            Cancel
+          </UButton>
+
+          <UButton
+            color="error"
+            :loading="deletingVersionDraft"
+            @click="deleteVersionDraft"
+          >
+            Delete Version Draft
+          </UButton>
+        </div>
+      </template>
+    </UModal>
+
     <UModal v-model:open="deleteModalOpen" title="Delete Draft Poster">
       <template #body>
         <p class="text-sm">

--- a/app/pages/dashboard.vue
+++ b/app/pages/dashboard.vue
@@ -24,6 +24,8 @@ type Poster = {
   imageUrl: string;
   automated: boolean;
   status: "draft" | "downloaded" | "published";
+  tombstone: boolean;
+  tombedReason: string;
   versionSequence: number;
   publishedAt: Date | null;
   created: Date;
@@ -332,7 +334,21 @@ function startVersionExtractionPolling(jobId: string) {
         pollingVersionJobId.value = null;
         await refreshPosterList();
         if (!keepPanelOpen && response.posterId) {
-          await navigateTo(`/share/${response.posterId}`);
+          const completedPoster = posters.value.find(
+            (poster) => poster.activeVersionDraft?.id === response.posterId,
+          );
+          const completedDraft = completedPoster?.activeVersionDraft;
+
+          toast.add({
+            title: completedDraft
+              ? `Version ${completedDraft.versionSequence} is ready to review`
+              : "Your new version is ready to review",
+            description: completedPoster
+              ? `Metadata extraction finished for ${completedPoster.title}. Select the poster to continue reviewing it.`
+              : "Metadata extraction finished. Select the poster to continue reviewing it.",
+            color: "success",
+            icon: "i-lucide-circle-check",
+          });
         }
 
         return;
@@ -517,13 +533,27 @@ onMounted(() => {
 onBeforeUnmount(stopVersionExtractionPolling);
 
 function openPoster(poster: Poster) {
+  if (poster.tombstone) return;
+
   if (poster.activeVersionDraft) {
-    openVersionModal(poster);
+    openVersionWorkflow(poster);
   } else if (poster.status === "published") {
     void navigateTo(`/discover/${poster.rootPosterId}`);
   } else {
     void navigateTo(`/share/${poster.id}`);
   }
+}
+
+function openVersionWorkflow(poster: Poster) {
+  const draft = poster.activeVersionDraft;
+
+  if (isVersionReviewReady(draft) && draft) {
+    void navigateTo(`/share/${draft.id}`);
+
+    return;
+  }
+
+  openVersionModal(poster);
 }
 
 const regeneratingThumbnailIds = ref<number[]>([]);
@@ -693,7 +723,13 @@ const getImage = (poster: Poster) => {
         v-for="(poster, index) in posters"
         :key="poster.rootPosterId ?? index + 1"
         variant="ghost"
-        class="group h-50 cursor-pointer overflow-hidden rounded-none border-t border-b border-gray-100 transition-all duration-300 max-md:h-auto max-md:rounded-xl max-md:border max-md:bg-white max-md:shadow-sm max-md:hover:shadow-md dark:max-md:border-gray-800 dark:max-md:bg-gray-950"
+        class="group h-50 overflow-hidden rounded-none border-t border-b border-gray-100 transition-all duration-300 max-md:h-auto max-md:rounded-xl max-md:border max-md:bg-white max-md:shadow-sm dark:max-md:border-gray-800 dark:max-md:bg-gray-950"
+        :class="
+          poster.tombstone
+            ? 'cursor-not-allowed opacity-70'
+            : 'cursor-pointer max-md:hover:shadow-md'
+        "
+        :aria-disabled="poster.tombstone"
         @click="openPoster(poster)"
       >
         <div
@@ -708,7 +744,8 @@ const getImage = (poster: Poster) => {
                 `https://api.dicebear.com/9.x/shapes/svg?seed=${poster.id}`
               "
               :alt="poster.title"
-              class="max-h-[150px] w-full object-contain p-2 transition-transform duration-300 group-hover:scale-105 max-md:h-full max-md:max-h-none max-md:p-3"
+              class="max-h-[150px] w-full object-contain p-2 transition-transform duration-300 max-md:h-full max-md:max-h-none max-md:p-3"
+              :class="{ 'group-hover:scale-105': !poster.tombstone }"
             />
           </div>
 
@@ -826,7 +863,11 @@ const getImage = (poster: Poster) => {
 
               <div class="flex items-center gap-2 max-md:flex-wrap">
                 <UTooltip
-                  v-if="poster.status === 'published' && !poster.automated"
+                  v-if="
+                    poster.status === 'published' &&
+                    !poster.automated &&
+                    !poster.tombstone
+                  "
                   :text="versionActionTooltip(poster)"
                 >
                   <span class="inline-flex" @click.stop>
@@ -845,7 +886,7 @@ const getImage = (poster: Poster) => {
                       "
                       size="xs"
                       :disabled="versionActionDisabled(poster)"
-                      @click="openVersionModal(poster)"
+                      @click="openVersionWorkflow(poster)"
                     />
                   </span>
                 </UTooltip>
@@ -889,7 +930,26 @@ const getImage = (poster: Poster) => {
                   @click.stop="openDeleteModal(poster)"
                 />
 
+                <UTooltip
+                  v-if="poster.tombstone"
+                  :text="
+                    poster.tombedReason
+                      ? `Reason: ${poster.tombedReason}`
+                      : 'This poster has been removed from public discovery.'
+                  "
+                >
+                  <UBadge
+                    color="error"
+                    variant="solid"
+                    size="sm"
+                    icon="i-lucide-archive-x"
+                  >
+                    Tombstoned
+                  </UBadge>
+                </UTooltip>
+
                 <UBadge
+                  v-else
                   :color="
                     poster.status === 'published'
                       ? 'success'

--- a/app/pages/discover/[posterid]/index.vue
+++ b/app/pages/discover/[posterid]/index.vue
@@ -6,6 +6,7 @@ import {
   RESOURCE_TYPE_OPTIONS,
   RELATION_TYPE_OPTIONS,
 } from "@/utils/poster_schema";
+import { resolveDoiUrl } from "@/utils/doi";
 import type { WithContext, ScholarlyArticle } from "schema-dts";
 
 const route = useRoute();
@@ -13,7 +14,6 @@ const posterId = route.params.posterid as string;
 
 const { loggedIn } = useUserSession();
 const toast = useToast();
-const { siteEnv } = useRuntimeConfig().public;
 
 const versionQuery = Array.isArray(route.query.version)
   ? route.query.version[0]
@@ -42,12 +42,42 @@ const versionHistory = (api?.versions ?? []) as Array<{
   posterMetadata?: { version?: string | null; doi?: string | null } | null;
 }>;
 
+function historyVersionLabel(entry: (typeof versionHistory)[number]) {
+  return (
+    entry.posterMetadata?.version?.trim() ||
+    (api?.automated ? "Unspecified" : String(entry.versionSequence))
+  );
+}
+
+function historyVersionUrl(entry: (typeof versionHistory)[number]) {
+  // The API resolves this as public metadata first, then as the internal
+  // sequence for older entries that do not have a public version label.
+  const version =
+    entry.posterMetadata?.version?.trim() || String(entry.versionSequence);
+
+  return `/discover/${posterId}?version=${encodeURIComponent(version)}`;
+}
+
 const liked = ref(api?.liked ?? false);
 
 const liking = ref(false);
 
 const getDicebearUrl = (seed: string) =>
   `https://api.dicebear.com/9.x/shapes/svg?seed=${seed}`;
+
+const relatedIdentifierUrl = (relatedIdentifier: {
+  relatedIdentifier?: string;
+  relatedIdentifierType?: string;
+}) => {
+  const identifier = relatedIdentifier.relatedIdentifier?.trim();
+  if (!identifier) return "";
+  if (/^https?:\/\//i.test(identifier)) return identifier;
+  if (relatedIdentifier.relatedIdentifierType === "DOI") {
+    return resolveDoiUrl(identifier);
+  }
+
+  return "";
+};
 
 const onImageError = (event: Event, seed: string) => {
   const img = event.target as HTMLImageElement;
@@ -118,11 +148,7 @@ const poster = ref({
       ri.relationType ??
       "References",
     doi: ri.relatedIdentifier ?? "",
-    url: ri.relatedIdentifier?.startsWith("http")
-      ? ri.relatedIdentifier
-      : ri.relatedIdentifier
-        ? `https://doi.org/${ri.relatedIdentifier}`
-        : "",
+    url: relatedIdentifierUrl(ri),
   })),
   funding: (api?.fundingReferences ?? []).map((f: any) => ({
     agency: f.funderName ?? "Unknown Funder",
@@ -146,20 +172,8 @@ const poster = ref({
 
 const resolvedPosterUrl = computed(() => {
   if (!poster.value.doi) return null;
-  const isZenodoDoi = poster.value.doi.includes("/zenodo.");
-  if (!isZenodoDoi) return `https://doi.org/${poster.value.doi}`;
 
-  const isSandboxDoi = poster.value.doi.startsWith("10.5072/");
-  const isSandboxEnv =
-    siteEnv === "staging" || siteEnv === "development" || siteEnv === "dev";
-
-  if (isSandboxDoi || isSandboxEnv) {
-    const recordId = poster.value.doi.split("/zenodo.")[1];
-
-    return `https://sandbox.zenodo.org/records/${recordId}`;
-  }
-
-  return `https://doi.org/${poster.value.doi}`;
+  return resolveDoiUrl(poster.value.doi);
 });
 
 const posterSource = computed(() => {
@@ -374,6 +388,15 @@ const tabItems = [
     icon: "fluent:clover-48-filled",
     slot: "overview",
   },
+  ...(versionHistory.length > 1
+    ? [
+        {
+          label: "Versions",
+          icon: "i-lucide-history",
+          slot: "versions",
+        },
+      ]
+    : []),
   {
     label: "Related resources",
     icon: "ooui:reference",
@@ -777,7 +800,7 @@ const tabItems = [
                           v-if="identifier.identifierType === 'DOI'"
                           :to="
                             identifier.identifierType === 'DOI'
-                              ? `https://doi.org/${identifier.identifier}`
+                              ? resolveDoiUrl(identifier.identifier)
                               : identifier.url
                           "
                           target="_blank"
@@ -832,6 +855,47 @@ const tabItems = [
                 </div>
               </template>
 
+              <template #versions>
+                <UCard class="mt-4">
+                  <template #header>
+                    <h2 class="text-xl font-semibold">Version History</h2>
+                  </template>
+
+                  <div class="space-y-2">
+                    <a
+                      v-for="entry in versionHistory"
+                      :key="entry.versionSequence"
+                      :href="historyVersionUrl(entry)"
+                      class="border-default hover:bg-elevated flex items-center justify-between rounded-lg border px-3 py-3 text-sm"
+                    >
+                      <span class="font-medium">
+                        Version
+                        {{ historyVersionLabel(entry) }}
+                      </span>
+
+                      <UBadge
+                        :color="
+                          entry.versionSequence === api?.versionSequence
+                            ? 'primary'
+                            : 'neutral'
+                        "
+                        variant="soft"
+                      >
+                        {{
+                          entry.versionSequence === api?.versionSequence
+                            ? "Viewing"
+                            : entry.publishedAt
+                              ? new Intl.DateTimeFormat("en-US", {
+                                  dateStyle: "medium",
+                                }).format(new Date(entry.publishedAt))
+                              : "Published"
+                        }}
+                      </UBadge>
+                    </a>
+                  </div>
+                </UCard>
+              </template>
+
               <template #references>
                 <div>
                   <UCard v-if="poster.references.length > 0" class="mt-4">
@@ -873,49 +937,6 @@ const tabItems = [
           </div>
 
           <div class="flex flex-col gap-4">
-            <UCard v-if="versionHistory.length > 1">
-              <template #header>
-                <h3 class="text-lg font-semibold">Version History</h3>
-              </template>
-
-              <div class="space-y-2">
-                <a
-                  v-for="entry in versionHistory"
-                  :key="entry.versionSequence"
-                  :href="`/discover/${posterId}?version=${entry.versionSequence}`"
-                  class="border-default hover:bg-elevated flex items-center justify-between rounded-lg border px-3 py-2 text-sm"
-                >
-                  <span>
-                    Version
-                    {{
-                      api?.automated
-                        ? entry.posterMetadata?.version || "Unspecified"
-                        : entry.versionSequence
-                    }}
-                  </span>
-
-                  <UBadge
-                    :color="
-                      entry.versionSequence === api?.versionSequence
-                        ? 'primary'
-                        : 'neutral'
-                    "
-                    variant="soft"
-                  >
-                    {{
-                      entry.versionSequence === api?.versionSequence
-                        ? "Viewing"
-                        : entry.publishedAt
-                          ? new Intl.DateTimeFormat("en-US", {
-                              dateStyle: "medium",
-                            }).format(new Date(entry.publishedAt))
-                          : "Published"
-                    }}
-                  </UBadge>
-                </a>
-              </div>
-            </UCard>
-
             <UCard>
               <template #header>
                 <h3 class="text-lg font-semibold">Authors</h3>

--- a/app/pages/discover/[posterid]/index.vue
+++ b/app/pages/discover/[posterid]/index.vue
@@ -15,14 +15,12 @@ const { loggedIn } = useUserSession();
 const toast = useToast();
 const { siteEnv } = useRuntimeConfig().public;
 
-// Shares the global feedback modal state owned by the default layout, so we can
-// open the same "Share Your Feedback" dialog from this page.
-const feedbackOpen = useState("feedbackOpen", () => false);
-function openFeedback() {
-  feedbackOpen.value = true;
-}
-
-const { data: apiData, error } = await useFetch(`/api/discover/${posterId}`);
+const versionQuery = Array.isArray(route.query.version)
+  ? route.query.version[0]
+  : route.query.version;
+const { data: apiData, error } = await useFetch(
+  `/api/discover/${posterId}${versionQuery ? `?version=${encodeURIComponent(versionQuery)}` : ""}`,
+);
 
 if (error.value) {
   console.error(error.value);
@@ -38,6 +36,11 @@ if (error.value) {
 
 const api = apiData.value as any;
 const conf = api?.conference;
+const versionHistory = (api?.versions ?? []) as Array<{
+  versionSequence: number;
+  publishedAt?: string | null;
+  posterMetadata?: { version?: string | null; doi?: string | null } | null;
+}>;
 
 const liked = ref(api?.liked ?? false);
 
@@ -870,6 +873,49 @@ const tabItems = [
           </div>
 
           <div class="flex flex-col gap-4">
+            <UCard v-if="versionHistory.length > 1">
+              <template #header>
+                <h3 class="text-lg font-semibold">Version History</h3>
+              </template>
+
+              <div class="space-y-2">
+                <a
+                  v-for="entry in versionHistory"
+                  :key="entry.versionSequence"
+                  :href="`/discover/${posterId}?version=${entry.versionSequence}`"
+                  class="border-default hover:bg-elevated flex items-center justify-between rounded-lg border px-3 py-2 text-sm"
+                >
+                  <span>
+                    Version
+                    {{
+                      api?.automated
+                        ? entry.posterMetadata?.version || "Unspecified"
+                        : entry.versionSequence
+                    }}
+                  </span>
+
+                  <UBadge
+                    :color="
+                      entry.versionSequence === api?.versionSequence
+                        ? 'primary'
+                        : 'neutral'
+                    "
+                    variant="soft"
+                  >
+                    {{
+                      entry.versionSequence === api?.versionSequence
+                        ? "Viewing"
+                        : entry.publishedAt
+                          ? new Intl.DateTimeFormat("en-US", {
+                              dateStyle: "medium",
+                            }).format(new Date(entry.publishedAt))
+                          : "Published"
+                    }}
+                  </UBadge>
+                </a>
+              </div>
+            </UCard>
+
             <UCard>
               <template #header>
                 <h3 class="text-lg font-semibold">Authors</h3>

--- a/app/pages/share/[id]/index.vue
+++ b/app/pages/share/[id]/index.vue
@@ -162,22 +162,9 @@ if (data.value) {
 
   // Check if the poster is already published
   if (poster.status === "published" || poster.publishedAt) {
-    toast.add({
-      title: "Poster already published",
-      description:
-        "This poster has already been published! It is now viewable on the Discover page.",
-      color: "warning",
-    });
+    const rootPosterId = poster.rootPosterId ?? id;
 
-    // open the discover page for this poster in a new tab
-    window.open(`/discover/${id}`, "_blank");
-
-    await navigateTo("/dashboard");
-
-    throw createError({
-      statusCode: 400,
-      statusMessage: "Poster already published",
-    });
+    await navigateTo(`/discover/${rootPosterId}`, { replace: true });
   }
 
   if (poster.extractionJob) {

--- a/app/pages/share/[id]/index.vue
+++ b/app/pages/share/[id]/index.vue
@@ -2254,6 +2254,10 @@ const moveCreator = (index: number, direction: "up" | "down") => {
                       />
                     </UFormField>
                   </div>
+
+                  <p class="text-muted text-sm">
+                    An award URI requires an award number or award title.
+                  </p>
                 </div>
 
                 <UButton

--- a/app/pages/share/[id]/index.vue
+++ b/app/pages/share/[id]/index.vue
@@ -52,6 +52,7 @@ useSeoMeta({
 });
 
 const loading = ref(false);
+const isVersionedPoster = ref(false);
 const orcidErrors = ref<Record<string, string | undefined>>({});
 const orcidChecking = ref<Record<string, boolean | undefined>>({});
 const identifierTypeErrors = ref<Record<string, string | undefined>>({});
@@ -159,6 +160,7 @@ const { data, error } = await useFetch(`/api/poster/${id}`);
 
 if (data.value) {
   const poster = data.value as PosterResponse;
+  isVersionedPoster.value = poster.versionRootId != null;
 
   // Check if the poster is already published
   if (poster.status === "published" || poster.publishedAt) {
@@ -1029,17 +1031,43 @@ const moveCreator = (index: number, direction: "up" | "down") => {
 <template>
   <div class="mx-auto flex w-full max-w-screen-xl flex-col gap-6 px-6 pb-10">
     <UPageHeader
-      title="Review Metadata"
-      description="Review and edit the metadata we extracted for your poster submission. This metadata will be included in a poster.json file that will be shared along with your poster to make it more reusable and machine actionable. The metadata will also be registered in the Posters.science database to make your poster discoverable."
+      :description="
+        isVersionedPoster
+          ? 'You are reviewing metadata for a new version of this poster. The published version remains unchanged until you publish these changes.'
+          : 'Review and edit the metadata we extracted for your poster submission. This metadata will be included in a poster.json file that will be shared along with your poster to make it more reusable and machine actionable. The metadata will also be registered in the Posters.science database to make your poster discoverable.'
+      "
     >
       <template #headline>
         <UBreadcrumb
-          :items="[
-            { label: 'Dashboard', to: '/dashboard' },
-            { label: 'Upload Poster', to: '/share/new' },
-            { label: 'Review Metadata' },
-          ]"
+          :items="
+            isVersionedPoster
+              ? [
+                  { label: 'Dashboard', to: '/dashboard' },
+                  { label: 'Review Metadata' },
+                ]
+              : [
+                  { label: 'Dashboard', to: '/dashboard' },
+                  { label: 'Upload Poster', to: '/share/new' },
+                  { label: 'Review Metadata' },
+                ]
+          "
         />
+      </template>
+
+      <template #title>
+        <div class="flex flex-wrap items-end gap-3">
+          <h1>Review Metadata</h1>
+
+          <UBadge
+            v-if="isVersionedPoster"
+            color="primary"
+            variant="soft"
+            icon="i-lucide-git-branch"
+            class="mb-1"
+          >
+            New version
+          </UBadge>
+        </div>
       </template>
     </UPageHeader>
 

--- a/app/pages/share/[id]/publish.vue
+++ b/app/pages/share/[id]/publish.vue
@@ -331,6 +331,9 @@ const { data: posterData, error: posterError } = await useFetch(
     method: "GET",
   },
 );
+const posterDetailsUrl = computed(
+  () => `/discover/${posterData.value?.rootPosterId ?? id}`,
+);
 
 if (posterError.value) {
   console.error("Poster fetch error:", posterError.value);
@@ -819,7 +822,7 @@ async function handleArchive() {
                 View on Zenodo
               </UButton>
 
-              <UButton variant="outline" :to="`/share/${id}`">
+              <UButton variant="outline" :to="posterDetailsUrl">
                 View Poster Details
               </UButton>
             </div>

--- a/app/pages/share/[id]/publish.vue
+++ b/app/pages/share/[id]/publish.vue
@@ -14,6 +14,7 @@ const isProductionEnv = siteEnv === "production";
 
 // Shared license selection (used by Zenodo and simulated flows)
 const selectedLicense = ref("");
+const publicationVersion = ref("");
 
 // Download completion state
 const downloadComplete = ref(false);
@@ -240,19 +241,14 @@ const linkedDeposition = ref<{
 const previousVersionLicense = ref("");
 const isPosterVersion = ref(false);
 
-const linkedDepositionDescription = computed(() => {
-  if (!linkedDeposition.value) return "";
-
-  return linkedDeposition.value.version
-    ? `${linkedDeposition.value.title} (Version ${linkedDeposition.value.version})`
-    : linkedDeposition.value.title;
-});
 const existingDepositions = ref<
   {
     id: number;
     title: string;
     isPublished: boolean;
     conceptDoi?: string;
+    version?: string;
+    versionIndex?: number;
   }[]
 >([]);
 
@@ -291,6 +287,7 @@ const effectiveDepositionId = computed(() => {
 const readyToArchive = computed(
   () =>
     !!selectedLicense.value &&
+    (posterData.value?.automated || !!publicationVersion.value.trim()) &&
     (depositionMode.value === "new" ||
       (depositionMode.value === "existing" &&
         effectiveDepositionId.value !== undefined)),
@@ -333,6 +330,76 @@ const { data: posterData, error: posterError } = await useFetch(
 );
 const posterDetailsUrl = computed(
   () => `/discover/${posterData.value?.rootPosterId ?? id}`,
+);
+
+const selectedDepositionDetails = computed(() =>
+  existingDepositions.value.find(
+    (deposition) => deposition.id === effectiveDepositionId.value,
+  ),
+);
+
+function nextVersionLabel(version?: string, versionIndex?: number) {
+  const normalized = version?.trim();
+
+  if (normalized && /^\d+$/.test(normalized)) {
+    return String(Number.parseInt(normalized, 10) + 1);
+  }
+
+  if (versionIndex && Number.isInteger(versionIndex)) {
+    return String(versionIndex + 1);
+  }
+
+  return "";
+}
+
+const expectedPublicationVersion = computed(() => {
+  if (posterData.value?.automated) return "";
+
+  const localVersion = posterData.value?.posterMetadata?.version?.trim() ?? "";
+
+  if (depositionMode.value === "existing") {
+    const selected = selectedDepositionDetails.value;
+
+    if (selected) {
+      if (!selected.isPublished) {
+        return selected.version?.trim() || localVersion || "1";
+      }
+
+      return (
+        nextVersionLabel(selected.version, selected.versionIndex) ||
+        localVersion ||
+        "1"
+      );
+    }
+
+    if (
+      linkedDeposition.value &&
+      linkedDeposition.value.id === effectiveDepositionId.value
+    ) {
+      if (linkedDeposition.value.isDraft) {
+        return linkedDeposition.value.version?.trim() || localVersion || "1";
+      }
+
+      return nextVersionLabel(linkedDeposition.value.version) || localVersion;
+    }
+  }
+
+  return localVersion || "1";
+});
+
+// Keep the suggested value in sync with the chosen deposition until the user
+// deliberately replaces it with their own semantic version.
+watch(
+  expectedPublicationVersion,
+  (expected, previousExpected) => {
+    if (
+      !publicationVersion.value ||
+      publicationVersion.value === previousExpected
+    ) {
+      publicationVersion.value = expected;
+    }
+  },
+  { immediate: true },
 );
 
 if (posterError.value) {
@@ -477,6 +544,9 @@ async function handleArchive() {
         mode: depositionMode.value,
         existingDepositionId: effectiveDepositionId.value,
         license: selectedLicense.value || undefined,
+        version: posterData.value?.automated
+          ? undefined
+          : publicationVersion.value.trim(),
       }),
     });
 
@@ -552,7 +622,9 @@ async function handleArchive() {
         <UBreadcrumb
           :items="[
             { label: 'Dashboard', to: '/dashboard' },
-            { label: 'Upload Poster', to: '/share/new' },
+            ...(posterData?.versionRootId
+              ? []
+              : [{ label: 'Upload Poster', to: '/share/new' }]),
             { label: 'Review Metadata', to: `/share/${id}` },
             { label: 'Submit Poster' },
           ]"
@@ -878,10 +950,16 @@ async function handleArchive() {
                   <template #description>
                     <div class="flex flex-col items-start gap-2">
                       <p>
-                        {{
-                          linkedDepositionDescription ||
-                          `Zenodo record ${linkedDepositionId}`
-                        }}
+                        <span>
+                          {{
+                            linkedDeposition?.title ||
+                            `Zenodo record ${linkedDepositionId}`
+                          }}
+                        </span>
+
+                        <strong v-if="linkedDeposition?.version" class="ml-1">
+                          (Version {{ linkedDeposition.version }})
+                        </strong>
                       </p>
 
                       <UButton
@@ -930,6 +1008,21 @@ async function handleArchive() {
                     />
                   </div>
                 </template>
+              </div>
+
+              <!-- Version selection -->
+              <div v-if="!posterData?.automated" class="mt-4 max-w-md">
+                <p class="text-muted mb-2 text-sm">
+                  Version <span class="text-error">*</span>
+                </p>
+
+                <p class="text-muted mb-2 text-xs">Suggested version.</p>
+
+                <UInput
+                  v-model="publicationVersion"
+                  placeholder="Enter version"
+                  class="w-full"
+                />
               </div>
 
               <!-- License selection -->

--- a/app/pages/share/[id]/publish.vue
+++ b/app/pages/share/[id]/publish.vue
@@ -227,6 +227,26 @@ async function handleSimulatedArchive() {
 // Deposition selection state
 const depositionMode = ref<"new" | "existing">("new");
 const selectedDeposition = ref<number | undefined>(undefined);
+const manualDepositionId = ref("");
+const linkedDepositionId = ref<number | undefined>(undefined);
+const linkedDeposition = ref<{
+  id: number;
+  title: string;
+  version?: string;
+  doi?: string;
+  url: string;
+  isDraft: boolean;
+} | null>(null);
+const previousVersionLicense = ref("");
+const isPosterVersion = ref(false);
+
+const linkedDepositionDescription = computed(() => {
+  if (!linkedDeposition.value) return "";
+
+  return linkedDeposition.value.version
+    ? `${linkedDeposition.value.title} (Version ${linkedDeposition.value.version})`
+    : linkedDeposition.value.title;
+});
 const existingDepositions = ref<
   {
     id: number;
@@ -257,7 +277,15 @@ const depositionModeOptions = [
 ];
 
 watch(depositionMode, () => {
-  selectedDeposition.value = undefined;
+  if (!linkedDepositionId.value) selectedDeposition.value = undefined;
+});
+
+const effectiveDepositionId = computed(() => {
+  if (linkedDepositionId.value) return linkedDepositionId.value;
+  if (selectedDeposition.value) return selectedDeposition.value;
+  const manual = Number.parseInt(manualDepositionId.value, 10);
+
+  return Number.isFinite(manual) && manual > 0 ? manual : undefined;
 });
 
 const readyToArchive = computed(
@@ -265,7 +293,7 @@ const readyToArchive = computed(
     !!selectedLicense.value &&
     (depositionMode.value === "new" ||
       (depositionMode.value === "existing" &&
-        selectedDeposition.value !== undefined)),
+        effectiveDepositionId.value !== undefined)),
 );
 
 // Archive progress state
@@ -346,6 +374,17 @@ watch(
     zenodoConfigError.value = !data?.zenodoLoginURL;
     existingDepositions.value = (data?.existingDepositions ??
       []) as typeof existingDepositions.value;
+    linkedDepositionId.value = data?.linkedDepositionId;
+    linkedDeposition.value = data?.linkedDeposition ?? null;
+    previousVersionLicense.value = data?.suggestedLicense ?? "";
+    if (!selectedLicense.value && previousVersionLicense.value) {
+      selectedLicense.value = previousVersionLicense.value;
+    }
+    isPosterVersion.value = Boolean(data?.isVersion);
+    if (isPosterVersion.value) depositionMode.value = "existing";
+    if (linkedDepositionId.value) {
+      selectedDeposition.value = linkedDepositionId.value;
+    }
     zenodoLoading.value = false;
   },
 );
@@ -433,7 +472,7 @@ async function handleArchive() {
       body: JSON.stringify({
         posterId: id,
         mode: depositionMode.value,
-        existingDepositionId: selectedDeposition.value,
+        existingDepositionId: effectiveDepositionId.value,
         license: selectedLicense.value || undefined,
       }),
     });
@@ -810,32 +849,98 @@ async function handleArchive() {
 
           <div>
             <p class="text-muted mb-4 text-sm">
-              Is your poster already published on Zenodo or would you like to
-              create a new Zenodo publication?
+              {{
+                isPosterVersion
+                  ? "This will be published as a new version of an existing Zenodo record."
+                  : "Is your poster already published on Zenodo or would you like to create a new Zenodo publication?"
+              }}
             </p>
 
             <div>
               <URadioGroup
+                v-if="!isPosterVersion"
                 v-model="depositionMode"
                 :items="depositionModeOptions"
               />
 
               <!-- Existing deposition selector -->
               <div v-if="depositionMode === 'existing'" class="mt-4">
-                <p class="text-muted mb-2 text-sm">Select your Zenodo record</p>
+                <UAlert
+                  v-if="linkedDepositionId"
+                  color="success"
+                  variant="soft"
+                  icon="i-lucide-link"
+                  title="Zenodo record selected automatically"
+                >
+                  <template #description>
+                    <div class="flex flex-col items-start gap-2">
+                      <p>
+                        {{
+                          linkedDepositionDescription ||
+                          `Zenodo record ${linkedDepositionId}`
+                        }}
+                      </p>
 
-                <USelect
-                  v-model="selectedDeposition"
-                  :items="selectableDepositions"
-                  placeholder="Choose a deposition..."
-                  class="w-full max-w-md"
-                />
+                      <UButton
+                        v-if="linkedDeposition?.url"
+                        :to="linkedDeposition.url"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        color="neutral"
+                        variant="outline"
+                        size="xs"
+                        trailing-icon="i-lucide-external-link"
+                      >
+                        {{
+                          linkedDeposition.isDraft
+                            ? "Review draft on Zenodo"
+                            : "View record on Zenodo"
+                        }}
+                      </UButton>
+                    </div>
+                  </template>
+                </UAlert>
+
+                <template v-else>
+                  <p class="text-muted mb-2 text-sm">
+                    Select your Zenodo record
+                  </p>
+
+                  <USelect
+                    v-model="selectedDeposition"
+                    :items="selectableDepositions"
+                    placeholder="Choose a recent record..."
+                    class="w-full max-w-md"
+                  />
+
+                  <div class="mt-3 max-w-md">
+                    <p class="text-muted mb-2 text-sm">
+                      Or enter a Zenodo record ID
+                    </p>
+
+                    <UInput
+                      v-model="manualDepositionId"
+                      inputmode="numeric"
+                      placeholder="e.g. 12345678"
+                      class="w-full"
+                      :disabled="selectedDeposition !== undefined"
+                    />
+                  </div>
+                </template>
               </div>
 
               <!-- License selection -->
               <div class="mt-4">
                 <p class="text-muted mb-2 text-sm">
                   License <span class="text-error">*</span>
+                </p>
+
+                <p
+                  v-if="previousVersionLicense"
+                  class="text-muted mb-2 text-xs"
+                >
+                  Preselected from the previous version. You can change it for
+                  this version if needed.
                 </p>
 
                 <USelectMenu

--- a/app/pages/share/[id]/publish.vue
+++ b/app/pages/share/[id]/publish.vue
@@ -453,6 +453,7 @@ watch(
     isPosterVersion.value = Boolean(data?.isVersion);
     if (isPosterVersion.value) depositionMode.value = "existing";
     if (linkedDepositionId.value) {
+      depositionMode.value = "existing";
       selectedDeposition.value = linkedDepositionId.value;
     }
     zenodoLoading.value = false;

--- a/app/utils/doi.ts
+++ b/app/utils/doi.ts
@@ -23,3 +23,17 @@ export function validateDoi(input: string): string {
 
   return "";
 }
+
+export function resolveDoiUrl(input: string): string {
+  const doi = normalizeDoi(input);
+  const zenodoMatch = doi.match(/^10\.(5072|5281)\/zenodo\.(\d+)$/i);
+
+  if (zenodoMatch) {
+    const [, prefix, recordId] = zenodoMatch;
+    const host = prefix === "5072" ? "sandbox.zenodo.org" : "zenodo.org";
+
+    return `https://${host}/records/${recordId}`;
+  }
+
+  return `https://doi.org/${doi}`;
+}

--- a/app/utils/poster_schema.ts
+++ b/app/utils/poster_schema.ts
@@ -617,6 +617,7 @@ const FormCreatorSchema = z.object({
 export const posterResponseSchema = z.object({
   id: z.number(),
   rootPosterId: z.number().optional(),
+  versionRootId: z.number().nullable().optional(),
   title: z.string().optional(),
   description: z.string().optional(),
   status: z.enum(["draft", "published"]).optional(),

--- a/app/utils/poster_schema.ts
+++ b/app/utils/poster_schema.ts
@@ -806,6 +806,17 @@ const StrictFundingSchema = z
       message: "Scheme URI is required when the identifier type is Other",
       path: ["schemeUri"],
     },
+  )
+  .refine(
+    (data) =>
+      !data.awardUri?.trim() ||
+      !!data.awardNumber?.trim() ||
+      !!data.awardTitle?.trim(),
+    {
+      message:
+        "Award title or award number is required when an award URI is provided",
+      path: ["awardUri"],
+    },
   );
 
 const StrictConferenceSchema = z.object({

--- a/app/utils/poster_schema.ts
+++ b/app/utils/poster_schema.ts
@@ -616,6 +616,7 @@ const FormCreatorSchema = z.object({
 // Used to type the response from GET /api/poster/:id
 export const posterResponseSchema = z.object({
   id: z.number(),
+  rootPosterId: z.number().optional(),
   title: z.string().optional(),
   description: z.string().optional(),
   status: z.enum(["draft", "published"]).optional(),

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,8 +1,8 @@
 generator client {
-    provider        = "prisma-client"
-    previewFeatures = ["strictUndefinedChecks"]
-    output          = "../shared/generated/"
-    engineType      = "client"
+  provider        = "prisma-client"
+  previewFeatures = ["strictUndefinedChecks"]
+  output          = "../shared/generated/"
+  engineType      = "client"
 }
 
 // generator kysely {
@@ -13,250 +13,265 @@ generator client {
 // }
 
 datasource db {
-    provider = "postgresql"
+  provider = "postgresql"
 }
 
 model User {
-    id String @id @default(cuid(2))
+  id String @id @default(cuid(2))
 
-    givenName  String @default("") // first name
-    familyName String @default("") // last name
+  givenName  String @default("") // first name
+  familyName String @default("") // last name
 
-    emailAddress String @unique
-    password     String
+  emailAddress String @unique
+  password     String
 
-    emailVerified                 Boolean   @default(false)
-    emailVerifiedAt               DateTime?
-    emailVerificationToken        String?   @unique
-    emailVerificationTokenExpires DateTime?
+  emailVerified                 Boolean   @default(false)
+  emailVerifiedAt               DateTime?
+  emailVerificationToken        String?   @unique
+  emailVerificationTokenExpires DateTime?
 
-    role String @default("user") // user | admin
+  role String @default("user") // user | admin
 
-    created DateTime @default(now())
-    updated DateTime @updatedAt
-    Poster  Poster[]
+  created DateTime @default(now())
+  updated DateTime @updatedAt
+  Poster  Poster[]
 
-    ZenodoToken       ZenodoToken?
-    ZenodoDepositions ZenodoDeposition[]
+  ZenodoToken       ZenodoToken?
+  ZenodoDepositions ZenodoDeposition[]
 
-    likes Like[] @relation("UserLikes")
+  likes Like[] @relation("UserLikes")
 
-    userEmailVerifications UserEmailVerification[]
-    userForgotPasswords    UserForgotPassword[]
+  userEmailVerifications UserEmailVerification[]
+  userForgotPasswords    UserForgotPassword[]
 
-    adminAuditLogs AdminAuditLog[] @relation("AdminActions")
+  adminAuditLogs AdminAuditLog[] @relation("AdminActions")
 
-    @@index([emailAddress])
+  @@index([emailAddress])
 }
 
 model UserEmailVerification {
-    id String @id @default(cuid(2))
+  id String @id @default(cuid(2))
 
-    user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
-    userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String
 
-    verificationToken String   @unique
-    expiresAt         DateTime
+  verificationToken String   @unique
+  expiresAt         DateTime
 
-    created DateTime @default(now())
-    updated DateTime @updatedAt
+  created DateTime @default(now())
+  updated DateTime @updatedAt
 }
 
 model UserForgotPassword {
-    id String @id @default(cuid(2))
+  id String @id @default(cuid(2))
 
-    user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
-    userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String
 
-    resetToken String   @unique
-    expiresAt  DateTime
+  resetToken String   @unique
+  expiresAt  DateTime
 
-    created DateTime @default(now())
-    updated DateTime @updatedAt
+  created DateTime @default(now())
+  updated DateTime @updatedAt
 }
 
 model UserInterest {
-    id String @id @default(cuid(2))
+  id String @id @default(cuid(2))
 
-    emailAddress String @unique
+  emailAddress String @unique
 
-    created DateTime @default(now())
+  created DateTime @default(now())
 
-    @@index([emailAddress])
+  @@index([emailAddress])
 }
 
 model Poster {
-    id Int @id @default(autoincrement())
+  id Int @id @default(autoincrement())
 
-    title       String
-    description String
+  // Published poster versions are stored as separate rows while sharing the
+  // first poster's stable public identity. Root rows leave versionRootId
+  // null; every later version points directly at that root.
+  versionRoot     Poster?  @relation("PosterVersions", fields: [versionRootId], references: [id], onDelete: Cascade)
+  versionRootId   Int?
+  versions        Poster[] @relation("PosterVersions")
+  // Internal ordering slot reserved when a draft is created. This is not the
+  // user-facing PosterMetadata.version value.
+  versionSequence Int      @default(1)
+  isLatestVersion Boolean  @default(true)
 
-    imageUrl String
+  title       String
+  description String
 
-    status      String    @default("draft") // draft, downloaded, published
-    publishedAt DateTime?
+  imageUrl String
 
-    user   User   @relation(fields: [userId], references: [id])
-    userId String
+  status      String    @default("draft") // draft, downloaded, published
+  publishedAt DateTime?
 
-    randomInt Int @default(0) // a field to touch when data in a related table is updated - For sorting by last updated
+  user   User   @relation(fields: [userId], references: [id])
+  userId String
 
-    created DateTime @default(now())
-    updated DateTime @updatedAt
+  randomInt Int @default(0) // a field to touch when data in a related table is updated - For sorting by last updated
 
-    posterMetadata    PosterMetadata?
-    zenodoDepositions ZenodoDeposition?
+  created DateTime @default(now())
+  updated DateTime @updatedAt
 
-    extractionJob ExtractionJob?
+  posterMetadata    PosterMetadata?
+  zenodoDepositions ZenodoDeposition?
 
-    automated Boolean @default(false) // Whether the poster was created through automated extraction or manual submission
+  extractionJob ExtractionJob?
 
-    tombstone    Boolean @default(false) // true = retired/soft-deleted, hidden from public views
-    tombedReason String  @default("") // Why the poster was retired
+  automated Boolean @default(false) // Whether the poster was created through automated extraction or manual submission
 
-    likes Like[] @relation("PosterLikes")
+  tombstone    Boolean @default(false) // true = retired/soft-deleted, hidden from public views
+  tombedReason String  @default("") // Why the poster was retired
+
+  likes Like[] @relation("PosterLikes")
+
+  @@unique([versionRootId, versionSequence])
+  @@index([versionRootId, status])
+  @@index([status, tombstone, isLatestVersion])
 }
 
 model PosterMetadata {
-    poster   Poster @relation(fields: [posterId], references: [id], onDelete: Cascade)
-    posterId Int    @id
+  poster   Poster @relation(fields: [posterId], references: [id], onDelete: Cascade)
+  posterId Int    @id
 
-    doi String?
+  doi String?
 
-    identifiers Json @default("[]") // [{ identifier: string, identifierType: string }]
+  identifiers Json @default("[]") // [{ identifier: string, identifierType: string }]
 
-    creators Json @default("[]") // [{ name: string, nameType: string, nameIdentifiers: string[], affiliation: string[] }]
+  creators Json @default("[]") // [{ name: string, nameType: string, nameIdentifiers: string[], affiliation: string[] }]
 
-    publisher       String?
-    publicationYear Int?
+  publisher       String?
+  publicationYear Int?
 
-    subjects String[] @default([])
+  subjects String[] @default([])
 
-    domain   String?
-    language String?
-    version  String?
+  domain   String?
+  language String?
+  version  String?
 
-    size   String?
-    format String?
+  size   String?
+  format String?
 
-    license String? // SPDX identifier
+  license String? // SPDX identifier
 
-    fundingReferences Json @default("[]") // [{ funderName: string, funderIdentifier: string, funderIdentifierType: string, schemeUri: string, awardNumber: string, awardUri: string, awardTitle: string }]
+  fundingReferences Json @default("[]") // [{ funderName: string, funderIdentifier: string, funderIdentifierType: string, schemeUri: string, awardNumber: string, awardUri: string, awardTitle: string }]
 
-    conferenceName           String?
-    conferenceLocation       String?
-    conferenceUri            String?
-    conferenceIdentifier     String?
-    conferenceIdentifierType String?
-    conferenceYear           Int?
-    conferenceStartDate      String?
-    conferenceEndDate        String?
-    conferenceAcronym        String?
-    conferenceSeries         String?
+  conferenceName           String?
+  conferenceLocation       String?
+  conferenceUri            String?
+  conferenceIdentifier     String?
+  conferenceIdentifierType String?
+  conferenceYear           Int?
+  conferenceStartDate      String?
+  conferenceEndDate        String?
+  conferenceAcronym        String?
+  conferenceSeries         String?
 
-    dates Json @default("[]") // [{ date: string, dateType: string }] primarily for autoindexed posters
+  dates Json @default("[]") // [{ date: string, dateType: string }] primarily for autoindexed posters
 
-    relatedIdentifiers Json @default("[]") // [{ relatedIdentifier: string, relatedIdentifierType: string, relationType: string }]
+  relatedIdentifiers Json @default("[]") // [{ relatedIdentifier: string, relatedIdentifierType: string, relationType: string }]
 
-    posterContent Json @default("[]") // { sections: [{ sectionTitle: string, sectionContent: string }], unstructuredContent: string }
-    tableCaptions Json @default("[]") // [{ id: string, caption: string }]
-    imageCaptions Json @default("[]") // [{ id: string, caption: string }]
+  posterContent Json @default("[]") // { sections: [{ sectionTitle: string, sectionContent: string }], unstructuredContent: string }
+  tableCaptions Json @default("[]") // [{ id: string, caption: string }]
+  imageCaptions Json @default("[]") // [{ id: string, caption: string }]
 
-    created DateTime @default(now())
-    updated DateTime @updatedAt
+  created DateTime @default(now())
+  updated DateTime @updatedAt
 }
 
 model Like {
-    user   User   @relation("UserLikes", fields: [userId], references: [id], onDelete: Cascade)
-    userId String
+  user   User   @relation("UserLikes", fields: [userId], references: [id], onDelete: Cascade)
+  userId String
 
-    poster   Poster @relation("PosterLikes", fields: [posterId], references: [id], onDelete: Cascade)
-    posterId Int
+  poster   Poster @relation("PosterLikes", fields: [posterId], references: [id], onDelete: Cascade)
+  posterId Int
 
-    created DateTime @default(now())
-    updated DateTime @updatedAt
+  created DateTime @default(now())
+  updated DateTime @updatedAt
 
-    @@id([userId, posterId])
+  @@id([userId, posterId])
 }
 
 model ZenodoToken {
-    id String @id @default(cuid(2))
+  id String @id @default(cuid(2))
 
-    user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
-    userId String @unique
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String @unique
 
-    accessToken  String
-    refreshToken String
-    expiresAt    DateTime
+  accessToken  String
+  refreshToken String
+  expiresAt    DateTime
 
-    created DateTime @default(now())
-    updated DateTime @updatedAt
+  created DateTime @default(now())
+  updated DateTime @updatedAt
 
-    @@index([userId])
+  @@index([userId])
 }
 
 model ZenodoDeposition {
-    id String @id @default(cuid(2))
+  id String @id @default(cuid(2))
 
-    depositionId           Int     @unique // Last published Zenodo deposition ID
-    status                 String  @default("unpublished") // draft, published, unpublished
-    lastPublishedZenodoDoi String? // Last published Zenodo DOI
+  depositionId           Int     @unique // Last published Zenodo deposition ID
+  status                 String  @default("unpublished") // draft, published, unpublished
+  lastPublishedZenodoDoi String? // Last published Zenodo DOI
 
-    user   User   @relation(fields: [userId], references: [id])
-    userId String
+  user   User   @relation(fields: [userId], references: [id])
+  userId String
 
-    poster   Poster @relation(fields: [posterId], references: [id], onDelete: Cascade)
-    posterId Int    @unique
+  poster   Poster @relation(fields: [posterId], references: [id], onDelete: Cascade)
+  posterId Int    @unique
 
-    created DateTime @default(now())
-    updated DateTime @updatedAt
+  created DateTime @default(now())
+  updated DateTime @updatedAt
 }
 
 model AdminAuditLog {
-    id String @id @default(cuid(2))
+  id String @id @default(cuid(2))
 
-    adminUser   User   @relation("AdminActions", fields: [adminUserId], references: [id])
-    adminUserId String
+  adminUser   User   @relation("AdminActions", fields: [adminUserId], references: [id])
+  adminUserId String
 
-    action     String // e.g. DELETE_POSTER, UPDATE_USER_ROLE
-    entityType String // user | poster
-    entityId   String
+  action     String // e.g. DELETE_POSTER, UPDATE_USER_ROLE
+  entityType String // user | poster
+  entityId   String
 
-    details Json?
+  details Json?
 
-    created DateTime @default(now())
+  created DateTime @default(now())
 
-    @@index([adminUserId])
-    @@index([entityType])
-    @@index([created])
+  @@index([adminUserId])
+  @@index([entityType])
+  @@index([created])
 }
 
 model MetricsSnapshot {
-    id Int @id @default(autoincrement())
+  id Int @id @default(autoincrement())
 
-    payload Json
+  payload Json
 
-    generatedAt DateTime @default(now())
+  generatedAt DateTime @default(now())
 
-    @@index([generatedAt])
+  @@index([generatedAt])
 }
 
 model ExtractionJob {
-    // This record and the files will only be removed after the poster is published or a doi is submitted
-    id String @id @default(cuid(2))
+  // This record and the files will only be removed after the poster is published or a doi is submitted
+  id String @id @default(cuid(2))
 
-    poster   Poster @relation(fields: [posterId], references: [id], onDelete: Cascade)
-    posterId Int    @unique
+  poster   Poster @relation(fields: [posterId], references: [id], onDelete: Cascade)
+  posterId Int    @unique
 
-    fileName String
-    filePath String
+  fileName String
+  filePath String
 
-    completed Boolean @default(false)
-    status    String  @default("pending-extraction") // pending-extraction, processing, completed, failed
-    error     String? // Filled when job fails
+  completed Boolean @default(false)
+  status    String  @default("pending-extraction") // pending-extraction, processing, completed, failed
+  error     String? // Filled when job fails
 
-    created DateTime @default(now())
-    updated DateTime @updatedAt
+  created DateTime @default(now())
+  updated DateTime @updatedAt
 
-    @@index([status])
+  @@index([status])
 }

--- a/server/api/__sitemap__/posters.ts
+++ b/server/api/__sitemap__/posters.ts
@@ -12,6 +12,7 @@ export default defineSitemapEventHandler(async () => {
       where: {
         status: "published",
         tombstone: false,
+        isLatestVersion: true,
       },
       select: {
         id: true,

--- a/server/api/admin/posters/[id].delete.ts
+++ b/server/api/admin/posters/[id].delete.ts
@@ -14,7 +14,13 @@ export default defineEventHandler(async (event) => {
 
   const existing = await prisma.poster.findUnique({
     where: { id: posterId },
-    select: { id: true, title: true, userId: true, status: true },
+    select: {
+      id: true,
+      title: true,
+      userId: true,
+      status: true,
+      versionRootId: true,
+    },
   });
   if (!existing) {
     throw createError({ statusCode: 404, statusMessage: "Poster not found" });
@@ -31,8 +37,9 @@ export default defineEventHandler(async (event) => {
       });
     }
 
-    await prisma.poster.update({
-      where: { id: posterId },
+    const rootId = posterFamilyRootId(existing);
+    await prisma.poster.updateMany({
+      where: posterFamilyWhere(rootId),
       data: { tombstone: true, tombedReason: body.data.reason },
     });
 

--- a/server/api/admin/posters/[id]/restore.post.ts
+++ b/server/api/admin/posters/[id]/restore.post.ts
@@ -8,7 +8,13 @@ export default defineEventHandler(async (event) => {
 
   const existing = await prisma.poster.findUnique({
     where: { id: posterId },
-    select: { id: true, title: true, userId: true, tombstone: true },
+    select: {
+      id: true,
+      title: true,
+      userId: true,
+      tombstone: true,
+      versionRootId: true,
+    },
   });
   if (!existing) {
     throw createError({ statusCode: 404, statusMessage: "Poster not found" });
@@ -21,8 +27,9 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  await prisma.poster.update({
-    where: { id: posterId },
+  const rootId = posterFamilyRootId(existing);
+  await prisma.poster.updateMany({
+    where: posterFamilyWhere(rootId),
     data: { tombstone: false, tombedReason: "" },
   });
 

--- a/server/api/discover/[posterid]/index.get.ts
+++ b/server/api/discover/[posterid]/index.get.ts
@@ -27,25 +27,54 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, statusMessage: "Poster not found" });
   }
 
-  const requestedSequence = Number.parseInt(
-    String(getQuery(event).version ?? ""),
-    10,
-  );
-  const poster = await prisma.poster.findFirst({
-    where: {
-      status: "published",
-      ...posterFamilyWhere(rootPosterId),
-      ...(Number.isFinite(requestedSequence)
-        ? { versionSequence: requestedSequence }
-        : { isLatestVersion: true }),
-    },
-    orderBy: { versionSequence: "desc" },
-    include: {
-      user: { select: { givenName: true, familyName: true } },
-      posterMetadata: true,
-      _count: { select: { likes: true } },
-    },
-  });
+  const versionParam = getQuery(event).version;
+  const requestedVersion = (
+    Array.isArray(versionParam) ? versionParam[0] : versionParam
+  )
+    ?.toString()
+    .trim();
+  const requestedSequence = /^\d+$/.test(requestedVersion ?? "")
+    ? Number.parseInt(requestedVersion!, 10)
+    : undefined;
+  const posterInclude = {
+    user: { select: { givenName: true, familyName: true } },
+    posterMetadata: true,
+    _count: { select: { likes: true } },
+  } as const;
+
+  // Public URLs use the user-facing metadata label. The integer sequence is
+  // retained as a fallback for old links and records that predate version
+  // metadata.
+  let poster = requestedVersion
+    ? await prisma.poster.findFirst({
+        where: {
+          status: "published",
+          ...posterFamilyWhere(rootPosterId),
+          posterMetadata: { is: { version: requestedVersion } },
+        },
+        orderBy: { versionSequence: "desc" },
+        include: posterInclude,
+      })
+    : await prisma.poster.findFirst({
+        where: {
+          status: "published",
+          ...posterFamilyWhere(rootPosterId),
+          isLatestVersion: true,
+        },
+        orderBy: { versionSequence: "desc" },
+        include: posterInclude,
+      });
+
+  if (!poster && requestedSequence !== undefined) {
+    poster = await prisma.poster.findFirst({
+      where: {
+        status: "published",
+        ...posterFamilyWhere(rootPosterId),
+        versionSequence: requestedSequence,
+      },
+      include: posterInclude,
+    });
+  }
 
   if (!poster) {
     throw createError({ statusCode: 404, statusMessage: "Poster not found" });

--- a/server/api/discover/[posterid]/index.get.ts
+++ b/server/api/discover/[posterid]/index.get.ts
@@ -8,8 +8,38 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: "Invalid poster ID" });
   }
 
+  const requested = await prisma.poster.findFirst({
+    where: { id: posterId, status: "published" },
+    select: { id: true, versionRootId: true },
+  });
+
+  if (!requested) {
+    throw createError({ statusCode: 404, statusMessage: "Poster not found" });
+  }
+
+  const rootPosterId = posterFamilyRootId(requested);
+  const root = await prisma.poster.findFirst({
+    where: { id: rootPosterId, tombstone: false },
+    select: { id: true },
+  });
+
+  if (!root) {
+    throw createError({ statusCode: 404, statusMessage: "Poster not found" });
+  }
+
+  const requestedSequence = Number.parseInt(
+    String(getQuery(event).version ?? ""),
+    10,
+  );
   const poster = await prisma.poster.findFirst({
-    where: { id: posterId, status: "published", tombstone: false },
+    where: {
+      status: "published",
+      ...posterFamilyWhere(rootPosterId),
+      ...(Number.isFinite(requestedSequence)
+        ? { versionSequence: requestedSequence }
+        : { isLatestVersion: true }),
+    },
+    orderBy: { versionSequence: "desc" },
     include: {
       user: { select: { givenName: true, familyName: true } },
       posterMetadata: true,
@@ -29,10 +59,11 @@ export default defineEventHandler(async (event) => {
   const liked = userId
     ? Boolean(
         await prisma.like.findUnique({
-          where: { userId_posterId: { userId, posterId } },
+          where: { userId_posterId: { userId, posterId: rootPosterId } },
         }),
       )
     : false;
+  const likes = await prisma.like.count({ where: { posterId: rootPosterId } });
 
   const { umamiWebsiteId } = useRuntimeConfig();
 
@@ -59,11 +90,25 @@ export default defineEventHandler(async (event) => {
     }
   }
 
+  const versions = await prisma.poster.findMany({
+    where: { status: "published", ...posterFamilyWhere(rootPosterId) },
+    orderBy: { versionSequence: "desc" },
+    select: {
+      versionSequence: true,
+      publishedAt: true,
+      posterMetadata: { select: { version: true, doi: true } },
+    },
+  });
+
   return {
-    id: poster.id,
+    id: rootPosterId,
+    versionPosterId: poster.id,
+    versionSequence: poster.versionSequence,
+    isLatestVersion: poster.isLatestVersion,
+    versions,
     automated: poster.automated,
     views,
-    likes: poster._count.likes,
+    likes,
     liked,
     title: poster.title,
     description: poster.description,

--- a/server/api/discover/facets.get.ts
+++ b/server/api/discover/facets.get.ts
@@ -53,7 +53,11 @@ export default defineEventHandler(async (event): Promise<FacetsResponse> => {
     prisma.posterMetadata.groupBy({
       by: ["language"],
       where: {
-        poster: { status: "published", tombstone: false },
+        poster: {
+          status: "published",
+          tombstone: false,
+          isLatestVersion: true,
+        },
         language: { not: null },
       },
       _count: { _all: true },
@@ -63,7 +67,11 @@ export default defineEventHandler(async (event): Promise<FacetsResponse> => {
     prisma.posterMetadata.groupBy({
       by: ["license"],
       where: {
-        poster: { status: "published", tombstone: false },
+        poster: {
+          status: "published",
+          tombstone: false,
+          isLatestVersion: true,
+        },
         license: { not: null },
       },
       _count: { _all: true },
@@ -73,7 +81,11 @@ export default defineEventHandler(async (event): Promise<FacetsResponse> => {
     prisma.posterMetadata.groupBy({
       by: ["publicationYear"],
       where: {
-        poster: { status: "published", tombstone: false },
+        poster: {
+          status: "published",
+          tombstone: false,
+          isLatestVersion: true,
+        },
         publicationYear: { not: null, gte: 2000, lte: currentYear },
       },
       _count: { _all: true },
@@ -100,6 +112,7 @@ export default defineEventHandler(async (event): Promise<FacetsResponse> => {
         ) AS aff
         WHERE p.status = 'published'
           AND p.tombstone = false
+          AND p."isLatestVersion" = true
         GROUP BY institution
       ) sub
       WHERE institution IS NOT NULL AND institution != ''
@@ -123,6 +136,7 @@ export default defineEventHandler(async (event): Promise<FacetsResponse> => {
       ) AS fr
       WHERE p.status = 'published'
         AND p.tombstone = false
+        AND p."isLatestVersion" = true
         AND fr->>'funderName' IS NOT NULL
         AND fr->>'funderName' <> ''
     `,

--- a/server/api/discover/index.get.ts
+++ b/server/api/discover/index.get.ts
@@ -139,7 +139,11 @@ export default defineEventHandler(async (event) => {
   if (licenseCanonicalValues.length > 0) {
     const rawLicenses = await prisma.posterMetadata.findMany({
       where: {
-        poster: { status: "published", tombstone: false },
+        poster: {
+          status: "published",
+          tombstone: false,
+          isLatestVersion: true,
+        },
         license: { not: null },
       },
       select: { license: true },
@@ -170,6 +174,7 @@ export default defineEventHandler(async (event) => {
       ) AS aff
       WHERE p.status = 'published'
         AND p.tombstone = false
+        AND p."isLatestVersion" = true
         AND lower(trim(
           CASE
             WHEN jsonb_typeof(aff) = 'object' THEN aff->>'name'
@@ -200,6 +205,7 @@ export default defineEventHandler(async (event) => {
       ) AS fr
       WHERE p.status = 'published'
         AND p.tombstone = false
+        AND p."isLatestVersion" = true
         AND fr->>'funderName' IS NOT NULL
         AND fr->>'funderName' <> ''
     `;
@@ -238,6 +244,7 @@ export default defineEventHandler(async (event) => {
   const whereClause = {
     status: "published",
     tombstone: false,
+    isLatestVersion: true,
     ...searchFilter,
     ...sourceFilter,
     ...metadataFilter,
@@ -259,6 +266,9 @@ export default defineEventHandler(async (event) => {
         _count: {
           select: { likes: true },
         },
+        versionRoot: {
+          select: { _count: { select: { likes: true } } },
+        },
       },
     })) || [];
   markStep("db-findMany");
@@ -268,11 +278,14 @@ export default defineEventHandler(async (event) => {
   });
   markStep("db-count");
 
-  const posters = rawPosters.map(({ posterMetadata, _count, ...poster }) => ({
-    ...poster,
-    keywords: posterMetadata?.subjects ?? [],
-    likes: _count?.likes ?? 0,
-  }));
+  const posters = rawPosters.map(
+    ({ posterMetadata, _count, versionRoot, ...poster }) => ({
+      ...poster,
+      id: poster.versionRootId ?? poster.id,
+      keywords: posterMetadata?.subjects ?? [],
+      likes: versionRoot?._count.likes ?? _count?.likes ?? 0,
+    }),
+  );
   markStep("poster-map");
 
   const totalDurationMs = Date.now() - requestStartedAt;

--- a/server/api/discover/stats.get.ts
+++ b/server/api/discover/stats.get.ts
@@ -3,6 +3,7 @@ export default defineEventHandler(async () => {
     where: {
       status: "published",
       tombstone: false,
+      isLatestVersion: true,
       automated: false,
     },
   });
@@ -11,6 +12,7 @@ export default defineEventHandler(async () => {
     where: {
       status: "published",
       tombstone: false,
+      isLatestVersion: true,
       automated: true,
     },
   });

--- a/server/api/poster/[id]/index.delete.ts
+++ b/server/api/poster/[id]/index.delete.ts
@@ -47,13 +47,14 @@ export default defineEventHandler(async (event) => {
   const versionDraftReady =
     !poster.extractionJob ||
     poster.extractionJob.completed ||
-    poster.extractionJob.status === "completed";
+    poster.extractionJob.status === "completed" ||
+    poster.extractionJob.status === "failed";
 
   if (poster.versionRootId !== null && !versionDraftReady) {
     throw createError({
       statusCode: 409,
       statusMessage:
-        "Version drafts cannot be deleted until metadata extraction is ready for review",
+        "Version drafts cannot be deleted while metadata extraction is still running",
     });
   }
 
@@ -65,7 +66,10 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  if (poster.zenodoDepositions?.status === "draft") {
+  if (
+    poster.zenodoDepositions?.status === "draft" ||
+    poster.zenodoDepositions?.status === "draft-new"
+  ) {
     const discarded = await discardZenodoDraft(
       user.id,
       poster.zenodoDepositions.depositionId,

--- a/server/api/poster/[id]/index.delete.ts
+++ b/server/api/poster/[id]/index.delete.ts
@@ -20,7 +20,10 @@ export default defineEventHandler(async (event) => {
     select: {
       id: true,
       status: true,
-      extractionJob: { select: { filePath: true } },
+      versionRootId: true,
+      extractionJob: {
+        select: { filePath: true, status: true, completed: true },
+      },
       zenodoDepositions: {
         select: { depositionId: true, status: true },
       },
@@ -38,6 +41,19 @@ export default defineEventHandler(async (event) => {
     throw createError({
       statusCode: 400,
       statusMessage: "Published posters cannot be deleted",
+    });
+  }
+
+  const versionDraftReady =
+    !poster.extractionJob ||
+    poster.extractionJob.completed ||
+    poster.extractionJob.status === "completed";
+
+  if (poster.versionRootId !== null && !versionDraftReady) {
+    throw createError({
+      statusCode: 409,
+      statusMessage:
+        "Version drafts cannot be deleted until metadata extraction is ready for review",
     });
   }
 

--- a/server/api/poster/[id]/index.delete.ts
+++ b/server/api/poster/[id]/index.delete.ts
@@ -1,3 +1,5 @@
+import { discardZenodoDraft } from "../../../utils/zenodo";
+
 export default defineEventHandler(async (event) => {
   const session = await requireUserSession(event);
 
@@ -19,6 +21,9 @@ export default defineEventHandler(async (event) => {
       id: true,
       status: true,
       extractionJob: { select: { filePath: true } },
+      zenodoDepositions: {
+        select: { depositionId: true, status: true },
+      },
     },
   });
 
@@ -34,6 +39,28 @@ export default defineEventHandler(async (event) => {
       statusCode: 400,
       statusMessage: "Published posters cannot be deleted",
     });
+  }
+
+  if (poster.zenodoDepositions?.status === "published") {
+    throw createError({
+      statusCode: 409,
+      statusMessage:
+        "This version has already been published to Zenodo and cannot be deleted as a draft",
+    });
+  }
+
+  if (poster.zenodoDepositions?.status === "draft") {
+    const discarded = await discardZenodoDraft(
+      user.id,
+      poster.zenodoDepositions.depositionId,
+    );
+
+    if (!discarded.success) {
+      throw createError({
+        statusCode: 502,
+        statusMessage: discarded.error,
+      });
+    }
   }
 
   const filePath = poster.extractionJob?.filePath;

--- a/server/api/poster/[id]/index.get.ts
+++ b/server/api/poster/[id]/index.get.ts
@@ -21,6 +21,7 @@ export default defineEventHandler(async (event) => {
     },
     include: {
       posterMetadata: true,
+      zenodoDepositions: true,
       extractionJob: {
         select: {
           completed: true,
@@ -40,8 +41,24 @@ export default defineEventHandler(async (event) => {
   }
 
   const meta = poster.posterMetadata;
+  const rootPosterId = posterFamilyRootId(poster);
+  const versions = await prisma.poster.findMany({
+    where: {
+      userId,
+      status: "published",
+      ...posterFamilyWhere(rootPosterId),
+    },
+    orderBy: { versionSequence: "desc" },
+    select: {
+      id: true,
+      versionSequence: true,
+      publishedAt: true,
+      posterMetadata: { select: { version: true, doi: true } },
+    },
+  });
+
   if (!meta) {
-    return poster;
+    return { ...poster, rootPosterId, versions };
   }
 
   // Normalize posterContent: DB may store array (sections) or object
@@ -84,6 +101,8 @@ export default defineEventHandler(async (event) => {
 
   return {
     ...poster,
+    rootPosterId,
+    versions,
     posterMetadata: {
       ...meta,
       posterContent,

--- a/server/api/poster/[id]/index.put.ts
+++ b/server/api/poster/[id]/index.put.ts
@@ -115,7 +115,6 @@ export default defineEventHandler(async (event) => {
   const relatedIdentifiers = data.relatedIdentifiers ?? [];
   const size = data.size || null;
   const format = data.format || null;
-  // Posters published through Posters.science use the immutable family sequence.
   // Preserve imported metadata versions only for automated posters, whose prior
   // version history is not known to us.
   const version = existingPoster.automated

--- a/server/api/poster/[id]/index.put.ts
+++ b/server/api/poster/[id]/index.put.ts
@@ -115,7 +115,12 @@ export default defineEventHandler(async (event) => {
   const relatedIdentifiers = data.relatedIdentifiers ?? [];
   const size = data.size || null;
   const format = data.format || null;
-  const version = data.version || null;
+  // Posters published through Posters.science use the immutable family sequence.
+  // Preserve imported metadata versions only for automated posters, whose prior
+  // version history is not known to us.
+  const version = existingPoster.automated
+    ? data.version || null
+    : posterVersionLabel(existingPoster.versionSequence);
   const license = data.license || null;
   // The review form derives schemeUri from the identifier type and hides the field for
   // every type except "Other", so back-stop it here: a draft save skips validation, and

--- a/server/api/poster/[id]/versions.post.ts
+++ b/server/api/poster/[id]/versions.post.ts
@@ -7,13 +7,14 @@ type RelatedIdentifier = {
 };
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
-const ALLOWED_TYPES = new Set([
-  "application/pdf",
-  "image/jpeg",
-  "image/png",
-  "image/webp",
-]);
-const ALLOWED_EXTENSIONS = new Set(["pdf", "jpg", "jpeg", "png", "webp"]);
+const ALLOWED_FILE_TYPES: Record<string, string> = {
+  pdf: "application/pdf",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+};
+const GENERIC_UPLOAD_TYPES = new Set(["", "application/octet-stream"]);
 
 function fieldValue(
   formData: Awaited<ReturnType<typeof readMultipartFormData>>,
@@ -28,8 +29,24 @@ function fieldValue(
 
 function isAllowedPosterFile(name: string, type: string) {
   const extension = name.split(".").pop()?.toLowerCase() ?? "";
+  const expectedType = ALLOWED_FILE_TYPES[extension];
+  const normalizedType = type.split(";", 1)[0]?.trim().toLowerCase() ?? "";
 
-  return ALLOWED_TYPES.has(type) || ALLOWED_EXTENSIONS.has(extension);
+  return Boolean(
+    expectedType &&
+    (normalizedType === expectedType ||
+      GENERIC_UPLOAD_TYPES.has(normalizedType)),
+  );
+}
+
+function isExtractionReady(
+  extractionJob: { status: string; completed: boolean } | null | undefined,
+) {
+  return Boolean(
+    !extractionJob ||
+    extractionJob.completed ||
+    extractionJob.status === "completed",
+  );
 }
 
 export default defineEventHandler(async (event) => {
@@ -43,11 +60,18 @@ export default defineEventHandler(async (event) => {
 
   const requested = await prisma.poster.findFirst({
     where: { id: requestedId, userId: session.user.id },
-    select: { id: true, versionRootId: true },
+    select: { id: true, versionRootId: true, tombstone: true },
   });
 
   if (!requested) {
     throw createError({ statusCode: 404, statusMessage: "Poster not found" });
+  }
+
+  if (requested.tombstone) {
+    throw createError({
+      statusCode: 409,
+      statusMessage: "Tombstoned posters cannot be versioned",
+    });
   }
 
   const rootId = posterFamilyRootId(requested);
@@ -66,6 +90,9 @@ export default defineEventHandler(async (event) => {
     select: {
       id: true,
       versionSequence: true,
+      imageUrl: true,
+      title: true,
+      description: true,
       extractionJob: { select: { id: true, status: true, completed: true } },
     },
   });
@@ -74,9 +101,12 @@ export default defineEventHandler(async (event) => {
     return {
       posterId: activeDraft.id,
       versionSequence: activeDraft.versionSequence,
+      imageUrl: activeDraft.imageUrl,
+      title: activeDraft.title,
+      description: activeDraft.description,
       extractionJobId: activeDraft.extractionJob?.id,
       extractionStatus: activeDraft.extractionJob?.status,
-      reviewReady: activeDraft.extractionJob?.completed ?? true,
+      reviewReady: isExtractionReady(activeDraft.extractionJob),
       resumed: true,
     };
   }
@@ -107,7 +137,21 @@ export default defineEventHandler(async (event) => {
     include: { posterMetadata: true, extractionJob: true },
   });
 
-  if (!source || !source.posterMetadata || !source.extractionJob?.filePath) {
+  if (!source) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Only a published poster can be versioned",
+    });
+  }
+
+  if (source.tombstone) {
+    throw createError({
+      statusCode: 409,
+      statusMessage: "Tombstoned posters cannot be versioned",
+    });
+  }
+
+  if (!source.posterMetadata || !source.extractionJob?.filePath) {
     throw createError({
       statusCode: 400,
       statusMessage:
@@ -166,12 +210,22 @@ export default defineEventHandler(async (event) => {
   }
 
   const config = useRuntimeConfig(event);
-  const { bunnyPrivateStorage, bunnyPrivateStorageKey } = config;
+  const { bunnyPrivateStorage, bunnyPrivateStorageKey, posterExtractionApi } =
+    config;
 
   if (!bunnyPrivateStorage || !bunnyPrivateStorageKey) {
     throw createError({
       statusCode: 503,
       statusMessage: "Poster storage is not configured",
+    });
+  }
+
+  const needsPosterService =
+    metadataMode === "extract" || fileMode === "upload" || !source.imageUrl;
+  if (needsPosterService && !posterExtractionApi) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: "Poster extraction service is not configured",
     });
   }
 
@@ -224,15 +278,27 @@ export default defineEventHandler(async (event) => {
 
   const nextSequence = source.versionSequence + 1;
   const originalFolderPath = originalPathParts.slice(0, -1).join("/");
-  const filePath = `${originalFolderPath}/version-${nextSequence}/${fileName}`;
+  const storageId = createId();
+  const filePath = `${originalFolderPath}/version-${nextSequence}-${storageId}/${fileName}`;
   const cleanupStoredVersion = async () => {
     const folderPath = filePath.slice(0, filePath.lastIndexOf("/") + 1);
-    await fetch(`${bunnyPrivateStorage}/${folderPath}`, {
-      method: "DELETE",
-      headers: { AccessKey: bunnyPrivateStorageKey },
-    }).catch((error) =>
-      console.error("[poster/version] Failed to clean up version file", error),
-    );
+    try {
+      const cleanupResponse = await fetch(
+        `${bunnyPrivateStorage}/${folderPath}`,
+        {
+          method: "DELETE",
+          headers: { AccessKey: bunnyPrivateStorageKey },
+        },
+      );
+
+      if (!cleanupResponse.ok) {
+        console.error(
+          `[poster/version] Failed to clean up ${folderPath}: ${cleanupResponse.status}`,
+        );
+      }
+    } catch (error) {
+      console.error("[poster/version] Failed to clean up version file", error);
+    }
   };
   const storageResponse = await fetch(`${bunnyPrivateStorage}/${filePath}`, {
     method: "PUT",
@@ -353,7 +419,11 @@ export default defineEventHandler(async (event) => {
           },
         },
       },
-      include: { extractionJob: { select: { id: true } } },
+      include: {
+        extractionJob: {
+          select: { id: true, status: true, completed: true },
+        },
+      },
     });
   } catch (error) {
     if ((error as { code?: string }).code === "P2002") {
@@ -363,18 +433,26 @@ export default defineEventHandler(async (event) => {
           versionSequence: nextSequence,
           status: { not: "published" },
         },
-        include: { extractionJob: { select: { id: true, completed: true } } },
+        include: {
+          extractionJob: {
+            select: { id: true, status: true, completed: true },
+          },
+        },
       });
       if (concurrent) {
-        // The version path is deterministic. A concurrent request writes to
-        // the same folder, so deleting it here could remove the winning
-        // request's file.
+        // Each request uses a unique storage folder, so the losing request can
+        // safely remove its upload without affecting the winning draft.
+        await cleanupStoredVersion();
 
         return {
           posterId: concurrent.id,
           versionSequence: concurrent.versionSequence,
+          imageUrl: concurrent.imageUrl,
+          title: concurrent.title,
+          description: concurrent.description,
           extractionJobId: concurrent.extractionJob?.id,
-          reviewReady: concurrent.extractionJob?.completed ?? true,
+          extractionStatus: concurrent.extractionJob?.status,
+          reviewReady: isExtractionReady(concurrent.extractionJob),
           resumed: true,
         };
       }
@@ -384,33 +462,80 @@ export default defineEventHandler(async (event) => {
     throw error;
   }
 
-  if (metadataMode === "extract" && config.posterExtractionApi) {
-    setImmediate(() => {
-      fetch(`${config.posterExtractionApi}/jobs/check`, {
-        method: "POST",
-      }).catch((error) =>
-        console.error("[poster/version] Failed to trigger extraction", error),
+  const responseFailure = async (label: string, response: Response) => {
+    const detail = (await response.text().catch(() => "")).slice(0, 500);
+
+    return `${label} failed with status ${response.status}${detail ? `: ${detail}` : ""}`;
+  };
+  const markPendingExtractionFailed = async (message: string) => {
+    try {
+      await prisma.extractionJob.updateMany({
+        where: { posterId: created.id, status: "pending-extraction" },
+        data: { status: "failed", completed: false, error: message },
+      });
+    } catch (error) {
+      console.error(
+        "[poster/version] Could not mark extraction trigger as failed",
+        error,
       );
+    }
+  };
+
+  if (metadataMode === "extract" && posterExtractionApi) {
+    setImmediate(async () => {
+      try {
+        const response = await fetch(`${posterExtractionApi}/jobs/check`, {
+          method: "POST",
+        });
+        if (!response.ok) {
+          throw new Error(
+            await responseFailure("Extraction trigger", response),
+          );
+        }
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Extraction trigger failed";
+        console.error("[poster/version] Failed to trigger extraction", error);
+        await markPendingExtractionFailed(message);
+      }
     });
-  } else if (fileMode === "upload" && config.posterExtractionApi) {
-    setImmediate(() => {
-      fetch(`${config.posterExtractionApi}/thumbnails/generate`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ pdf_path: filePath, poster_id: created.id }),
-      }).catch((error) =>
-        console.error("[poster/version] Failed to trigger thumbnail", error),
-      );
+  }
+
+  // A missing thumbnail must be generated from this version's stored file.
+  // This covers replacement files and reused files whose source thumbnail was
+  // unavailable without borrowing an image from an older poster version.
+  if (!created.imageUrl && posterExtractionApi) {
+    setImmediate(async () => {
+      try {
+        const response = await fetch(
+          `${posterExtractionApi}/thumbnails/generate`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              pdf_path: filePath,
+              poster_id: created.id,
+            }),
+          },
+        );
+        if (!response.ok) {
+          throw new Error(await responseFailure("Thumbnail trigger", response));
+        }
+      } catch (error) {
+        console.error("[poster/version] Failed to trigger thumbnail", error);
+      }
     });
   }
 
   return {
     posterId: created.id,
     versionSequence: created.versionSequence,
+    imageUrl: created.imageUrl,
+    title: created.title,
+    description: created.description,
     extractionJobId: created.extractionJob?.id,
-    extractionStatus:
-      metadataMode === "copy" ? "completed" : "pending-extraction",
-    reviewReady: metadataMode === "copy",
+    extractionStatus: created.extractionJob?.status,
+    reviewReady: isExtractionReady(created.extractionJob),
     resumed: false,
   };
 });

--- a/server/api/poster/[id]/versions.post.ts
+++ b/server/api/poster/[id]/versions.post.ts
@@ -1,0 +1,416 @@
+type Identifier = { identifier?: string; identifierType?: string };
+type RelatedIdentifier = {
+  relatedIdentifier?: string;
+  relatedIdentifierType?: string;
+  relationType?: string;
+  resourceTypeGeneral?: string;
+};
+
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+const ALLOWED_TYPES = new Set([
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+const ALLOWED_EXTENSIONS = new Set(["pdf", "jpg", "jpeg", "png", "webp"]);
+
+function fieldValue(
+  formData: Awaited<ReturnType<typeof readMultipartFormData>>,
+  name: string,
+) {
+  const field = formData?.find(
+    (entry) => entry.name === name && !entry.filename,
+  );
+
+  return field?.data.toString("utf8");
+}
+
+function isAllowedPosterFile(name: string, type: string) {
+  const extension = name.split(".").pop()?.toLowerCase() ?? "";
+
+  return ALLOWED_TYPES.has(type) || ALLOWED_EXTENSIONS.has(extension);
+}
+
+export default defineEventHandler(async (event) => {
+  const session = await requireUserSession(event);
+  const { id } = event.context.params as { id: string };
+  const requestedId = Number.parseInt(id, 10);
+
+  if (!Number.isFinite(requestedId)) {
+    throw createError({ statusCode: 400, statusMessage: "Invalid poster ID" });
+  }
+
+  const requested = await prisma.poster.findFirst({
+    where: { id: requestedId, userId: session.user.id },
+    select: { id: true, versionRootId: true },
+  });
+
+  if (!requested) {
+    throw createError({ statusCode: 404, statusMessage: "Poster not found" });
+  }
+
+  const rootId = posterFamilyRootId(requested);
+  const familyWhere = {
+    userId: session.user.id,
+    ...posterFamilyWhere(rootId),
+  };
+
+  const activeDraft = await prisma.poster.findFirst({
+    where: {
+      ...familyWhere,
+      status: { not: "published" },
+      id: { not: rootId },
+    },
+    orderBy: { versionSequence: "desc" },
+    select: {
+      id: true,
+      versionSequence: true,
+      extractionJob: { select: { id: true, status: true, completed: true } },
+    },
+  });
+
+  if (activeDraft) {
+    return {
+      posterId: activeDraft.id,
+      versionSequence: activeDraft.versionSequence,
+      extractionJobId: activeDraft.extractionJob?.id,
+      extractionStatus: activeDraft.extractionJob?.status,
+      reviewReady: activeDraft.extractionJob?.completed ?? true,
+      resumed: true,
+    };
+  }
+
+  const blockingExtraction = await prisma.poster.findFirst({
+    where: {
+      userId: session.user.id,
+      versionRootId: { not: null },
+      status: { not: "published" },
+      extractionJob: {
+        is: { status: { in: ["pending-extraction", "processing"] } },
+      },
+    },
+    select: { id: true, title: true },
+  });
+
+  if (blockingExtraction) {
+    throw createError({
+      statusCode: 409,
+      statusMessage: `Wait for metadata extraction on “${blockingExtraction.title}” to finish before starting another version`,
+      data: { posterId: blockingExtraction.id },
+    });
+  }
+
+  const source = await prisma.poster.findFirst({
+    where: { ...familyWhere, status: "published" },
+    orderBy: { versionSequence: "desc" },
+    include: { posterMetadata: true, extractionJob: true },
+  });
+
+  if (!source || !source.posterMetadata || !source.extractionJob?.filePath) {
+    throw createError({
+      statusCode: 400,
+      statusMessage:
+        "Only a published poster with a stored file can be versioned",
+    });
+  }
+
+  if (source.automated) {
+    throw createError({
+      statusCode: 400,
+      statusMessage:
+        "Auto-indexed posters cannot be versioned through Posters.science",
+    });
+  }
+
+  const rootPoster = await prisma.poster.findFirst({
+    where: { id: rootId, userId: session.user.id },
+    select: { extractionJob: { select: { filePath: true } } },
+  });
+  const originalFilePath = rootPoster?.extractionJob?.filePath.replace(
+    /^\/+/,
+    "",
+  );
+  const originalPathParts = originalFilePath?.split("/") ?? [];
+
+  if (
+    !originalFilePath ||
+    originalPathParts.length < 4 ||
+    originalPathParts[0] !== "posters" ||
+    originalPathParts.includes("..")
+  ) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "The original poster storage location is invalid",
+    });
+  }
+
+  const formData = await readMultipartFormData(event);
+  const fileMode = fieldValue(formData, "fileMode");
+  const metadataMode = fieldValue(formData, "metadataMode");
+
+  if (fileMode !== "reuse" && fileMode !== "upload") {
+    throw createError({ statusCode: 400, statusMessage: "Invalid file mode" });
+  }
+  if (metadataMode !== "copy" && metadataMode !== "extract") {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Invalid metadata mode",
+    });
+  }
+  if (fileMode === "reuse" && metadataMode !== "copy") {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Metadata extraction requires a newly uploaded file",
+    });
+  }
+
+  const config = useRuntimeConfig(event);
+  const { bunnyPrivateStorage, bunnyPrivateStorageKey } = config;
+
+  if (!bunnyPrivateStorage || !bunnyPrivateStorageKey) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: "Poster storage is not configured",
+    });
+  }
+
+  const uploaded = formData?.find(
+    (entry) => entry.name === "file" && entry.filename,
+  );
+  let fileName = source.extractionJob.fileName;
+  let fileType = "application/octet-stream";
+  let fileBytes: Uint8Array;
+
+  if (fileMode === "upload") {
+    if (!uploaded?.data || !uploaded.filename) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: "No version file provided",
+      });
+    }
+    fileName = uploaded.filename.replace(/[^a-zA-Z0-9._-]/g, "_");
+    fileType = uploaded.type || "application/octet-stream";
+    fileBytes = uploaded.data;
+
+    if (!isAllowedPosterFile(fileName, fileType)) {
+      throw createError({
+        statusCode: 415,
+        statusMessage: "File must be a PDF, JPEG, PNG, or WebP image",
+      });
+    }
+  } else {
+    const response = await fetch(
+      `${bunnyPrivateStorage}/${source.extractionJob.filePath}`,
+      { headers: { AccessKey: bunnyPrivateStorageKey } },
+    );
+
+    if (!response.ok) {
+      throw createError({
+        statusCode: 502,
+        statusMessage: "Could not copy the existing poster file",
+      });
+    }
+    fileType = response.headers.get("Content-Type") ?? fileType;
+    fileBytes = new Uint8Array(await response.arrayBuffer());
+  }
+
+  if (fileBytes.byteLength > MAX_FILE_SIZE_BYTES) {
+    throw createError({
+      statusCode: 413,
+      statusMessage: "File must be 10MB or smaller",
+    });
+  }
+
+  const nextSequence = source.versionSequence + 1;
+  const originalFolderPath = originalPathParts.slice(0, -1).join("/");
+  const filePath = `${originalFolderPath}/version-${nextSequence}/${fileName}`;
+  const cleanupStoredVersion = async () => {
+    const folderPath = filePath.slice(0, filePath.lastIndexOf("/") + 1);
+    await fetch(`${bunnyPrivateStorage}/${folderPath}`, {
+      method: "DELETE",
+      headers: { AccessKey: bunnyPrivateStorageKey },
+    }).catch((error) =>
+      console.error("[poster/version] Failed to clean up version file", error),
+    );
+  };
+  const storageResponse = await fetch(`${bunnyPrivateStorage}/${filePath}`, {
+    method: "PUT",
+    headers: {
+      AccessKey: bunnyPrivateStorageKey,
+      "Content-Type": fileType,
+      "Content-Length": String(fileBytes.byteLength),
+    },
+    body: fileBytes.buffer.slice(
+      fileBytes.byteOffset,
+      fileBytes.byteOffset + fileBytes.byteLength,
+    ) as ArrayBuffer,
+  });
+
+  if (!storageResponse.ok) {
+    await cleanupStoredVersion();
+
+    throw createError({
+      statusCode: 502,
+      statusMessage: "Failed to store version file",
+    });
+  }
+
+  const meta = source.posterMetadata;
+  const previousDoi = meta.doi?.trim();
+  const identifiers = Array.isArray(meta.identifiers)
+    ? (meta.identifiers as Identifier[]).filter(
+        (identifier) =>
+          !(
+            previousDoi &&
+            identifier.identifierType?.toUpperCase() === "DOI" &&
+            identifier.identifier?.trim().toLowerCase() ===
+              previousDoi.toLowerCase()
+          ),
+      )
+    : [];
+  const relatedIdentifiers = Array.isArray(meta.relatedIdentifiers)
+    ? ([...meta.relatedIdentifiers] as RelatedIdentifier[])
+    : [];
+
+  if (
+    previousDoi &&
+    !relatedIdentifiers.some(
+      (item) =>
+        item.relatedIdentifier?.toLowerCase() === previousDoi.toLowerCase() &&
+        item.relationType === "IsNewVersionOf",
+    )
+  ) {
+    relatedIdentifiers.push({
+      relatedIdentifier: previousDoi,
+      relatedIdentifierType: "DOI",
+      relationType: "IsNewVersionOf",
+      resourceTypeGeneral: "Text",
+    });
+  }
+
+  const dates = Array.isArray(meta.dates)
+    ? (meta.dates as Array<{ dateType?: string }>).filter(
+        (date) => date.dateType !== "Submitted",
+      )
+    : [];
+  const version = posterVersionLabel(nextSequence);
+
+  const metadataCreate = {
+    doi: null,
+    identifiers,
+    creators: meta.creators,
+    publisher: meta.publisher,
+    publicationYear: meta.publicationYear,
+    subjects: meta.subjects,
+    domain: meta.domain,
+    language: meta.language,
+    version,
+    size: meta.size,
+    format: meta.format,
+    license: meta.license,
+    fundingReferences: meta.fundingReferences,
+    conferenceName: meta.conferenceName,
+    conferenceLocation: meta.conferenceLocation,
+    conferenceUri: meta.conferenceUri,
+    conferenceIdentifier: meta.conferenceIdentifier,
+    conferenceIdentifierType: meta.conferenceIdentifierType,
+    conferenceYear: meta.conferenceYear,
+    conferenceStartDate: meta.conferenceStartDate,
+    conferenceEndDate: meta.conferenceEndDate,
+    conferenceAcronym: meta.conferenceAcronym,
+    conferenceSeries: meta.conferenceSeries,
+    dates,
+    relatedIdentifiers,
+    posterContent: meta.posterContent,
+    tableCaptions: meta.tableCaptions,
+    imageCaptions: meta.imageCaptions,
+  };
+
+  let created;
+  try {
+    created = await prisma.poster.create({
+      data: {
+        userId: session.user.id,
+        versionRootId: rootId,
+        versionSequence: nextSequence,
+        isLatestVersion: false,
+        title: source.title,
+        description: source.description,
+        imageUrl: fileMode === "reuse" ? source.imageUrl : "",
+        status: "draft",
+        automated: source.automated,
+        ...(metadataMode === "copy" && {
+          posterMetadata: { create: metadataCreate as never },
+        }),
+        extractionJob: {
+          create: {
+            fileName,
+            filePath,
+            completed: metadataMode === "copy",
+            status:
+              metadataMode === "copy" ? "completed" : "pending-extraction",
+          },
+        },
+      },
+      include: { extractionJob: { select: { id: true } } },
+    });
+  } catch (error) {
+    if ((error as { code?: string }).code === "P2002") {
+      const concurrent = await prisma.poster.findFirst({
+        where: {
+          ...familyWhere,
+          versionSequence: nextSequence,
+          status: { not: "published" },
+        },
+        include: { extractionJob: { select: { id: true, completed: true } } },
+      });
+      if (concurrent) {
+        // The version path is deterministic. A concurrent request writes to
+        // the same folder, so deleting it here could remove the winning
+        // request's file.
+
+        return {
+          posterId: concurrent.id,
+          versionSequence: concurrent.versionSequence,
+          extractionJobId: concurrent.extractionJob?.id,
+          reviewReady: concurrent.extractionJob?.completed ?? true,
+          resumed: true,
+        };
+      }
+    }
+
+    await cleanupStoredVersion();
+    throw error;
+  }
+
+  if (metadataMode === "extract" && config.posterExtractionApi) {
+    setImmediate(() => {
+      fetch(`${config.posterExtractionApi}/jobs/check`, {
+        method: "POST",
+      }).catch((error) =>
+        console.error("[poster/version] Failed to trigger extraction", error),
+      );
+    });
+  } else if (fileMode === "upload" && config.posterExtractionApi) {
+    setImmediate(() => {
+      fetch(`${config.posterExtractionApi}/thumbnails/generate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ pdf_path: filePath, poster_id: created.id }),
+      }).catch((error) =>
+        console.error("[poster/version] Failed to trigger thumbnail", error),
+      );
+    });
+  }
+
+  return {
+    posterId: created.id,
+    versionSequence: created.versionSequence,
+    extractionJobId: created.extractionJob?.id,
+    extractionStatus:
+      metadataMode === "copy" ? "completed" : "pending-extraction",
+    reviewReady: metadataMode === "copy",
+    resumed: false,
+  };
+});

--- a/server/api/poster/index.get.ts
+++ b/server/api/poster/index.get.ts
@@ -69,6 +69,9 @@ export default defineEventHandler(async (event) => {
         ? {
             id: activeVersionDraft.id,
             versionSequence: activeVersionDraft.versionSequence,
+            imageUrl: activeVersionDraft.imageUrl,
+            title: activeVersionDraft.title,
+            description: activeVersionDraft.description,
             extractionJob: activeVersionDraft.extractionJob,
           }
         : null,

--- a/server/api/poster/index.get.ts
+++ b/server/api/poster/index.get.ts
@@ -4,7 +4,7 @@ export default defineEventHandler(async (event) => {
   const { user } = session;
   const userId = user.id;
 
-  const posters = await prisma.poster.findMany({
+  const posterRows = await prisma.poster.findMany({
     include: {
       posterMetadata: {
         select: {
@@ -12,11 +12,22 @@ export default defineEventHandler(async (event) => {
           publicationYear: true,
           doi: true,
           license: true,
+          version: true,
         },
       },
       extractionJob: {
         select: {
+          id: true,
           status: true,
+          completed: true,
+          error: true,
+        },
+      },
+      zenodoDepositions: {
+        select: {
+          depositionId: true,
+          status: true,
+          lastPublishedZenodoDoi: true,
         },
       },
     },
@@ -28,5 +39,39 @@ export default defineEventHandler(async (event) => {
     },
   });
 
-  return posters || [];
+  const families = new Map<number, typeof posterRows>();
+
+  for (const poster of posterRows) {
+    const rootId = posterFamilyRootId(poster);
+    const family = families.get(rootId) ?? [];
+    family.push(poster);
+    families.set(rootId, family);
+  }
+
+  return [...families.entries()].map(([rootPosterId, family]) => {
+    const ordered = [...family].sort(
+      (a, b) => b.versionSequence - a.versionSequence,
+    );
+    const latestPublished = ordered.find(
+      (poster) => poster.status === "published",
+    );
+    const activeVersionDraft = ordered.find(
+      (poster) => poster.id !== rootPosterId && poster.status !== "published",
+    );
+    const displayed = latestPublished ?? ordered[0]!;
+
+    return {
+      ...displayed,
+      rootPosterId,
+      versionCount: family.filter((poster) => poster.status === "published")
+        .length,
+      activeVersionDraft: activeVersionDraft
+        ? {
+            id: activeVersionDraft.id,
+            versionSequence: activeVersionDraft.versionSequence,
+            extractionJob: activeVersionDraft.extractionJob,
+          }
+        : null,
+    };
+  });
 });

--- a/server/api/poster/job/[id].get.ts
+++ b/server/api/poster/job/[id].get.ts
@@ -33,32 +33,81 @@ export default defineEventHandler(async (event) => {
         ? "https://sandbox.posters.science"
         : "https://posters.science";
 
+    const versionPoster = await prisma.poster.findUnique({
+      where: { id: job.posterId },
+      select: { id: true, versionRootId: true, versionSequence: true },
+    });
+    const rootPosterId = versionPoster
+      ? posterFamilyRootId(versionPoster)
+      : job.posterId;
+    const previousVersion = versionPoster?.versionRootId
+      ? await prisma.poster.findFirst({
+          where: {
+            status: "published",
+            versionSequence: { lt: versionPoster.versionSequence },
+            ...posterFamilyWhere(rootPosterId),
+          },
+          orderBy: { versionSequence: "desc" },
+          select: { posterMetadata: { select: { doi: true } } },
+        })
+      : null;
     const meta = await prisma.posterMetadata.findUnique({
       where: { posterId: job.posterId },
-      select: { relatedIdentifiers: true },
+      select: { relatedIdentifiers: true, version: true },
     });
 
     if (meta) {
       const existing = Array.isArray(meta.relatedIdentifiers)
-        ? (meta.relatedIdentifiers as Array<{ relatedIdentifier?: string }>)
+        ? (meta.relatedIdentifiers as Array<{
+            relatedIdentifier?: string;
+            relatedIdentifierType?: string;
+            relationType?: string;
+            resourceTypeGeneral?: string;
+          }>)
         : [];
+      const canonicalUrl = `${baseUrl}/discover/${rootPosterId}`;
       const alreadyPresent = existing.some(
-        (r) => r.relatedIdentifier === `${baseUrl}/discover/${job.posterId}`,
+        (r) => r.relatedIdentifier === canonicalUrl,
       );
+      const previousDoi = previousVersion?.posterMetadata?.doi;
+      const hasPreviousVersion = previousDoi
+        ? existing.some(
+            (r) =>
+              r.relatedIdentifier?.toLowerCase() ===
+                previousDoi.toLowerCase() &&
+              r.relationType === "IsNewVersionOf",
+          )
+        : true;
+      const relatedIdentifiers = [...existing];
+      const assignedVersion = versionPoster?.versionRootId
+        ? posterVersionLabel(versionPoster.versionSequence)
+        : null;
 
       if (!alreadyPresent) {
+        relatedIdentifiers.push({
+          relatedIdentifier: canonicalUrl,
+          relatedIdentifierType: "URL",
+          relationType: "IsDescribedBy",
+        });
+      }
+      if (previousDoi && !hasPreviousVersion) {
+        relatedIdentifiers.push({
+          relatedIdentifier: previousDoi,
+          relatedIdentifierType: "DOI",
+          relationType: "IsNewVersionOf",
+        });
+      }
+
+      if (
+        !alreadyPresent ||
+        !hasPreviousVersion ||
+        (assignedVersion && meta.version !== assignedVersion)
+      ) {
         await prisma.posterMetadata.update({
           where: { posterId: job.posterId },
           data: {
-            relatedIdentifiers: [
-              ...existing,
-              {
-                relatedIdentifier: `${baseUrl}/discover/${job.posterId}`,
-                relatedIdentifierType: "URL",
-                relationType: "IsDescribedBy",
-                resourceTypeGeneral: "Other",
-              },
-            ] as never,
+            relatedIdentifiers: relatedIdentifiers as never,
+            ...(assignedVersion && { version: assignedVersion }),
           },
         });
       }

--- a/server/api/poster/job/[id].get.ts
+++ b/server/api/poster/job/[id].get.ts
@@ -13,6 +13,9 @@ export default defineEventHandler(async (event) => {
 
   const job = await prisma.extractionJob.findFirst({
     where: { id: jobId, poster: { userId: user.id } },
+    include: {
+      poster: { select: { imageUrl: true, title: true, description: true } },
+    },
   });
 
   if (!job) {
@@ -120,5 +123,8 @@ export default defineEventHandler(async (event) => {
     completed: job.completed,
     posterId: job.posterId,
     error: job.error,
+    imageUrl: job.poster.imageUrl,
+    title: job.poster.title,
+    description: job.poster.description,
   };
 });

--- a/server/api/poster/job/[id]/retry.post.ts
+++ b/server/api/poster/job/[id]/retry.post.ts
@@ -1,0 +1,74 @@
+export default defineEventHandler(async (event) => {
+  const session = await requireUserSession(event);
+  const { id: jobId } = event.context.params as { id: string };
+
+  if (!jobId) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Job ID is required",
+    });
+  }
+
+  const job = await prisma.extractionJob.findFirst({
+    where: { id: jobId, poster: { userId: session.user.id } },
+    select: {
+      id: true,
+      status: true,
+      poster: { select: { status: true, versionRootId: true } },
+    },
+  });
+
+  if (!job) {
+    throw createError({ statusCode: 404, statusMessage: "Job not found" });
+  }
+  if (!job.poster.versionRootId || job.poster.status === "published") {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Only unpublished poster versions can be retried",
+    });
+  }
+  if (job.status !== "failed") {
+    throw createError({
+      statusCode: 409,
+      statusMessage: "Only failed extraction jobs can be retried",
+    });
+  }
+
+  const config = useRuntimeConfig(event);
+  if (!config.posterExtractionApi) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: "Poster extraction is not configured",
+    });
+  }
+
+  const pending = await prisma.extractionJob.update({
+    where: { id: job.id },
+    data: { status: "pending-extraction", completed: false, error: null },
+    select: { status: true, completed: true, error: true },
+  });
+
+  try {
+    const response = await fetch(`${config.posterExtractionApi}/jobs/check`, {
+      method: "POST",
+    });
+
+    if (!response.ok) {
+      throw new Error(`Extraction service returned ${response.status}`);
+    }
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? `Could not restart extraction: ${error.message}`
+        : "Could not restart extraction";
+
+    await prisma.extractionJob.update({
+      where: { id: job.id },
+      data: { status: "failed", completed: false, error: message },
+    });
+
+    throw createError({ statusCode: 502, statusMessage: message });
+  }
+
+  return pending;
+});

--- a/server/api/release/zenodo/index.get.ts
+++ b/server/api/release/zenodo/index.get.ts
@@ -14,6 +14,109 @@ export default defineEventHandler(async (event) => {
 
   const { user } = session;
   const userId = user.id;
+  const posterIdInt = Number.parseInt(posterId, 10);
+  const poster = Number.isFinite(posterIdInt)
+    ? await prisma.poster.findFirst({
+        where: { id: posterIdInt, userId },
+        select: {
+          id: true,
+          versionRootId: true,
+          versionSequence: true,
+          zenodoDepositions: { select: { depositionId: true, status: true } },
+        },
+      })
+    : null;
+  const previousVersion = poster?.versionRootId
+    ? await prisma.poster.findFirst({
+        where: {
+          userId,
+          status: "published",
+          versionSequence: { lt: poster.versionSequence },
+          ...posterFamilyWhere(poster.versionRootId),
+        },
+        orderBy: { versionSequence: "desc" },
+        select: { posterMetadata: { select: { license: true } } },
+      })
+    : null;
+  const suggestedLicense =
+    previousVersion?.posterMetadata?.license ?? undefined;
+  let linkedDepositionId =
+    poster?.zenodoDepositions?.status === "draft"
+      ? poster.zenodoDepositions.depositionId
+      : undefined;
+  let linkedDeposition:
+    | {
+        id: number;
+        title: string;
+        version?: string;
+        doi?: string;
+        url: string;
+        isDraft: boolean;
+      }
+    | undefined;
+
+  if (linkedDepositionId && poster) {
+    const posterDetails = await prisma.poster.findUnique({
+      where: { id: poster.id },
+      select: {
+        title: true,
+        posterMetadata: { select: { version: true, doi: true } },
+      },
+    });
+    linkedDeposition = {
+      id: linkedDepositionId,
+      title: posterDetails?.title ?? "Poster version draft",
+      ...(posterDetails?.posterMetadata?.version && {
+        version: posterDetails.posterMetadata.version,
+      }),
+      ...(posterDetails?.posterMetadata?.doi && {
+        doi: posterDetails.posterMetadata.doi,
+      }),
+      url: `${config.zenodoEndpoint}/uploads/${linkedDepositionId}`,
+      isDraft: true,
+    };
+  }
+
+  if (!linkedDepositionId && poster?.versionRootId) {
+    const predecessor = await prisma.poster.findFirst({
+      where: {
+        userId,
+        status: "published",
+        versionSequence: { lt: poster.versionSequence },
+        ...posterFamilyWhere(poster.versionRootId),
+      },
+      orderBy: { versionSequence: "desc" },
+      select: {
+        title: true,
+        posterMetadata: { select: { version: true, doi: true } },
+        zenodoDepositions: {
+          select: {
+            depositionId: true,
+            lastPublishedZenodoDoi: true,
+          },
+        },
+      },
+    });
+    linkedDepositionId = predecessor?.zenodoDepositions?.depositionId;
+    if (linkedDepositionId && predecessor) {
+      linkedDeposition = {
+        id: linkedDepositionId,
+        title: predecessor.title,
+        ...(predecessor.posterMetadata?.version && {
+          version: predecessor.posterMetadata.version,
+        }),
+        ...((predecessor.zenodoDepositions?.lastPublishedZenodoDoi ??
+          predecessor.posterMetadata?.doi) && {
+          doi:
+            predecessor.zenodoDepositions?.lastPublishedZenodoDoi ??
+            predecessor.posterMetadata?.doi ??
+            undefined,
+        }),
+        url: `${config.zenodoEndpoint}/records/${linkedDepositionId}`,
+        isDraft: false,
+      };
+    }
+  }
 
   // Check if Zenodo is configured
   // redirectUri is checked too: without it Zenodo rejects the authorize request
@@ -61,6 +164,10 @@ export default defineEventHandler(async (event) => {
       zenodoToken,
       message,
       existingDepositions,
+      linkedDepositionId,
+      linkedDeposition,
+      suggestedLicense,
+      isVersion: Boolean(poster?.versionRootId),
     };
   } catch (error: unknown) {
     const errorMessage =

--- a/server/api/release/zenodo/index.post.ts
+++ b/server/api/release/zenodo/index.post.ts
@@ -1,6 +1,7 @@
 // Endpoint to begin the Zenodo archival publication workflow
 // Streams progress events via SSE as each step completes
 import { z } from "zod";
+import { cleanupFailedNewZenodoDeposition } from "../../../utils/zenodo";
 
 const payloadSchema = z.object({
   posterId: z.string(),
@@ -92,6 +93,10 @@ export default defineEventHandler(async (event) => {
     }
   } catch (error) {
     console.error("[Zenodo] Unexpected error during publication:", error);
+
+    if (mode === "new") {
+      await cleanupFailedNewZenodoDeposition(Number(posterId), userId);
+    }
 
     // Keep the real message: a generic string here makes shared screenshots
     // untraceable, and this branch catches network throws and Prisma errors.

--- a/server/api/release/zenodo/index.post.ts
+++ b/server/api/release/zenodo/index.post.ts
@@ -7,6 +7,7 @@ const payloadSchema = z.object({
   mode: z.enum(["new", "existing"]).default("new"),
   existingDepositionId: z.number().optional(),
   license: z.string().optional(),
+  version: z.string().trim().min(1).max(100).optional(),
 });
 
 export default defineEventHandler(async (event) => {
@@ -28,7 +29,8 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  const { posterId, mode, existingDepositionId, license } = parsed.data;
+  const { posterId, mode, existingDepositionId, license, version } =
+    parsed.data;
 
   // Publishing only needs the boolean, not the record list.
   const { zenodoToken, message } = await validateZenodoToken(userId, {
@@ -71,6 +73,7 @@ export default defineEventHandler(async (event) => {
       userId,
       (progress) => sendEvent(progress),
       license,
+      version,
     );
 
     if (!status.success) {

--- a/server/utils/computeMetrics.ts
+++ b/server/utils/computeMetrics.ts
@@ -54,11 +54,21 @@ export async function computeMetrics(client: PrismaClient) {
   ] = await Promise.all([
     // 1) count of published posters that are manually shared
     client.poster.count({
-      where: { status: "published", tombstone: false, automated: false },
+      where: {
+        status: "published",
+        tombstone: false,
+        automated: false,
+        isLatestVersion: true,
+      },
     }),
     // 2) count of published posters that are auto-indexed
     client.poster.count({
-      where: { status: "published", tombstone: false, automated: true },
+      where: {
+        status: "published",
+        tombstone: false,
+        automated: true,
+        isLatestVersion: true,
+      },
     }),
 
     // 3) monthly trend (last 13 months, client fills full 12-month window)
@@ -67,6 +77,7 @@ export async function computeMetrics(client: PrismaClient) {
       FROM "Poster"
       WHERE status = 'published'
         AND tombstone = false
+        AND "isLatestVersion" = true
         AND created >= NOW() - INTERVAL '13 months'
       GROUP BY month
       ORDER BY month ASC
@@ -76,7 +87,11 @@ export async function computeMetrics(client: PrismaClient) {
     client.posterMetadata.groupBy({
       by: ["domain"],
       where: {
-        poster: { status: "published", tombstone: false },
+        poster: {
+          status: "published",
+          tombstone: false,
+          isLatestVersion: true,
+        },
         domain: { not: null },
       },
       _count: { _all: true },
@@ -88,7 +103,11 @@ export async function computeMetrics(client: PrismaClient) {
     client.posterMetadata.groupBy({
       by: ["language"],
       where: {
-        poster: { status: "published", tombstone: false },
+        poster: {
+          status: "published",
+          tombstone: false,
+          isLatestVersion: true,
+        },
         language: { not: null },
       },
       _count: { _all: true },
@@ -99,7 +118,11 @@ export async function computeMetrics(client: PrismaClient) {
     client.posterMetadata.groupBy({
       by: ["license"],
       where: {
-        poster: { status: "published", tombstone: false },
+        poster: {
+          status: "published",
+          tombstone: false,
+          isLatestVersion: true,
+        },
         license: { not: null },
       },
       _count: { _all: true },
@@ -112,7 +135,11 @@ export async function computeMetrics(client: PrismaClient) {
     client.posterMetadata.groupBy({
       by: ["publisher"],
       where: {
-        poster: { status: "published", tombstone: false },
+        poster: {
+          status: "published",
+          tombstone: false,
+          isLatestVersion: true,
+        },
         publisher: { not: null },
       },
       _count: { _all: true },
@@ -123,7 +150,11 @@ export async function computeMetrics(client: PrismaClient) {
     client.posterMetadata.groupBy({
       by: ["conferenceYear"],
       where: {
-        poster: { status: "published", tombstone: false },
+        poster: {
+          status: "published",
+          tombstone: false,
+          isLatestVersion: true,
+        },
         conferenceYear: { not: null },
       },
       _count: { _all: true },
@@ -134,7 +165,11 @@ export async function computeMetrics(client: PrismaClient) {
     client.posterMetadata.groupBy({
       by: ["conferenceName"],
       where: {
-        poster: { status: "published", tombstone: false },
+        poster: {
+          status: "published",
+          tombstone: false,
+          isLatestVersion: true,
+        },
         conferenceName: { not: null },
       },
       _count: { _all: true },
@@ -151,6 +186,7 @@ export async function computeMetrics(client: PrismaClient) {
       JOIN "Poster" p ON pm."posterId" = p.id
       WHERE p.status = 'published'
         AND p.tombstone = false
+        AND p."isLatestVersion" = true
         AND subjects IS NOT NULL
         AND array_length(subjects, 1) > 0
       GROUP BY subject
@@ -180,6 +216,7 @@ export async function computeMetrics(client: PrismaClient) {
         ) AS aff
         WHERE p.status = 'published'
           AND p.tombstone = false
+          AND p."isLatestVersion" = true
       ) sub
       WHERE institution IS NOT NULL AND institution != ''
         AND trim(institution) !~ '^[0-9]+$'
@@ -210,6 +247,7 @@ export async function computeMetrics(client: PrismaClient) {
         ) AS aff
         WHERE p.status = 'published'
           AND p.tombstone = false
+          AND p."isLatestVersion" = true
         GROUP BY institution
       ) sub
       WHERE institution IS NOT NULL AND institution != ''
@@ -226,7 +264,11 @@ export async function computeMetrics(client: PrismaClient) {
     client.posterMetadata.groupBy({
       by: ["publicationYear"],
       where: {
-        poster: { status: "published", tombstone: false },
+        poster: {
+          status: "published",
+          tombstone: false,
+          isLatestVersion: true,
+        },
         publicationYear: { not: null, gte: 2000, lte: currentYear },
       },
       _count: { _all: true },
@@ -240,6 +282,7 @@ export async function computeMetrics(client: PrismaClient) {
       JOIN "Poster" p ON pm."posterId" = p.id
       WHERE p.status = 'published'
         AND p.tombstone = false
+        AND p."isLatestVersion" = true
         AND pm.doi IS NOT NULL
         AND pm.doi <> ''
     `,
@@ -278,6 +321,7 @@ export async function computeMetrics(client: PrismaClient) {
         CROSS JOIN LATERAL jsonb_array_elements(pm.creators) AS cr
         WHERE p.status = 'published'
           AND p.tombstone = false
+          AND p."isLatestVersion" = true
           AND jsonb_typeof(pm.creators) = 'array'
       )
       SELECT
@@ -305,6 +349,7 @@ export async function computeMetrics(client: PrismaClient) {
       ) AS aff
       WHERE p.status = 'published'
         AND p.tombstone = false
+        AND p."isLatestVersion" = true
         AND aff->>'affiliationIdentifierScheme' = 'ROR'
         AND aff->>'affiliationIdentifier' <> ''
     `,
@@ -324,6 +369,7 @@ export async function computeMetrics(client: PrismaClient) {
       ) AS fr
       WHERE p.status = 'published'
         AND p.tombstone = false
+        AND p."isLatestVersion" = true
         AND fr->>'funderName' IS NOT NULL
         AND fr->>'funderName' <> ''
     `,
@@ -335,6 +381,7 @@ export async function computeMetrics(client: PrismaClient) {
       JOIN "Poster" p ON pm."posterId" = p.id
       WHERE p.status = 'published'
         AND p.tombstone = false
+        AND p."isLatestVersion" = true
         AND pm.language IS NOT NULL
         AND pm.language <> ''
     `,

--- a/server/utils/posterVersions.ts
+++ b/server/utils/posterVersions.ts
@@ -1,0 +1,16 @@
+export function posterFamilyRootId(poster: {
+  id: number;
+  versionRootId: number | null;
+}): number {
+  return poster.versionRootId ?? poster.id;
+}
+
+export function posterFamilyWhere(rootId: number) {
+  return {
+    OR: [{ id: rootId }, { versionRootId: rootId }],
+  };
+}
+
+export function posterVersionLabel(sequence: number): string {
+  return String(sequence);
+}

--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -341,10 +341,132 @@ async function refreshZenodoToken(userId: string, refreshToken: string) {
   }
 }
 
-/**
- * Discards an unpublished InvenioRDM draft that is linked to a local poster.
- * A missing draft is already in the desired state, so retries remain safe.
- */
+type ZenodoRecordState =
+  | { kind: "published"; record: RdmRecord }
+  | { kind: "draft"; record: RdmRecord }
+  | { kind: "missing" }
+  | { kind: "unknown"; error: string };
+
+const NEW_DEPOSITION_DRAFT_STATUS = "draft-new";
+
+function isZenodoDraftStatus(status: string | null | undefined) {
+  return status === "draft" || status === NEW_DEPOSITION_DRAFT_STATUS;
+}
+
+async function resolveZenodoRecordState(
+  zenodoToken: string,
+  recordId: number,
+): Promise<ZenodoRecordState> {
+  try {
+    const published = await rdmGet(`/records/${recordId}`, zenodoToken);
+
+    if (published.ok) {
+      return {
+        kind: "published",
+        record: (await published.json()) as RdmRecord,
+      };
+    }
+
+    if (published.status !== 404) {
+      return {
+        kind: "unknown",
+        error: await getZenodoErrorMessage(
+          `Failed to check Zenodo record ${recordId}`,
+          published,
+        ),
+      };
+    }
+
+    const draft = await rdmGet(`/records/${recordId}/draft`, zenodoToken);
+
+    if (draft.ok) {
+      return { kind: "draft", record: (await draft.json()) as RdmRecord };
+    }
+
+    if (draft.status === 404) return { kind: "missing" };
+
+    return {
+      kind: "unknown",
+      error: await getZenodoErrorMessage(
+        `Failed to check Zenodo draft ${recordId}`,
+        draft,
+      ),
+    };
+  } catch (error) {
+    return {
+      kind: "unknown",
+      error: `Could not reach Zenodo while checking record ${recordId}: ${(error as Error).message}`,
+    };
+  }
+}
+
+async function discardRdmDraft(zenodoToken: string, recordId: number) {
+  const state = await resolveZenodoRecordState(zenodoToken, recordId);
+
+  if (state.kind === "published") {
+    return {
+      success: false as const,
+      published: state.record,
+      error: `Zenodo record ${recordId} has already been published and cannot be deleted as a draft.`,
+    };
+  }
+
+  if (state.kind === "unknown") {
+    return { success: false as const, error: state.error };
+  }
+
+  if (state.kind === "missing") return { success: true as const };
+
+  let response: Response;
+
+  try {
+    response = await fetch(
+      `${config.zenodoApiEndpoint}/records/${recordId}/draft`,
+      {
+        method: "DELETE",
+        headers: rdmHeaders(zenodoToken),
+      },
+    );
+  } catch (error) {
+    return {
+      success: false as const,
+      error: `Could not reach Zenodo while deleting draft ${recordId}: ${(error as Error).message}`,
+    };
+  }
+
+  if (response.ok) return { success: true as const };
+
+  if (response.status === 404) {
+    const afterDelete = await resolveZenodoRecordState(zenodoToken, recordId);
+
+    if (afterDelete.kind === "missing") return { success: true as const };
+    if (afterDelete.kind === "published") {
+      return {
+        success: false as const,
+        published: afterDelete.record,
+        error: `Zenodo record ${recordId} has already been published and cannot be deleted as a draft.`,
+      };
+    }
+    if (afterDelete.kind === "unknown") {
+      return { success: false as const, error: afterDelete.error };
+    }
+
+    return {
+      success: false as const,
+      error: `Zenodo draft ${recordId} still exists after the delete request.`,
+    };
+  }
+
+  return {
+    success: false as const,
+    error: await getZenodoErrorMessage(
+      `Failed to delete Zenodo draft ${recordId}`,
+      response,
+    ),
+  };
+}
+
+/** Discards a record only after confirming that it is still a draft. */
 export async function discardZenodoDraft(userId: string, recordId: number) {
   const tokenRecord = await getZenodoToken(userId);
 
@@ -356,34 +478,42 @@ export async function discardZenodoDraft(userId: string, recordId: number) {
     };
   }
 
-  let response: Response;
+  return discardRdmDraft(tokenRecord.accessToken, recordId);
+}
 
+/** Best-effort fallback for unexpected errors that escape the publication flow. */
+export async function cleanupFailedNewZenodoDeposition(
+  posterId: number,
+  userId: string,
+) {
   try {
-    response = await fetch(
-      `${config.zenodoApiEndpoint}/records/${recordId}/draft`,
-      {
-        method: "DELETE",
-        headers: rdmHeaders(tokenRecord.accessToken),
-      },
+    const [tokenRecord, deposition] = await Promise.all([
+      getZenodoToken(userId),
+      prisma.zenodoDeposition.findUnique({
+        where: { posterId },
+        select: { depositionId: true, status: true },
+      }),
+    ]);
+
+    if (!tokenRecord || deposition?.status !== NEW_DEPOSITION_DRAFT_STATUS)
+      return;
+
+    const cleanup = await cleanupCreatedDraft(
+      posterId,
+      deposition.depositionId,
+      tokenRecord.accessToken,
     );
+
+    if (!cleanup.success) {
+      console.error(
+        `[Zenodo] Emergency cleanup retained record ${deposition.depositionId}: ${cleanup.error}`,
+      );
+    }
   } catch (error) {
-    return {
-      success: false as const,
-      error: `Could not reach Zenodo while deleting draft ${recordId}: ${(error as Error).message}`,
-    };
+    console.error(
+      `[Zenodo] Emergency cleanup failed for poster ${posterId}: ${(error as Error).message}`,
+    );
   }
-
-  if (response.ok || response.status === 404) {
-    return { success: true as const };
-  }
-
-  return {
-    success: false as const,
-    error: await getZenodoErrorMessage(
-      `Failed to delete Zenodo draft ${recordId}`,
-      response,
-    ),
-  };
 }
 
 export type PublicationProgressEvent = {
@@ -397,6 +527,8 @@ type ProgressCallback = (
 ) => void | Promise<void>;
 
 type PosterIdentifier = { identifier: string; identifierType: string };
+type WorkingDraftOrigin = "new_deposition" | "new_version" | "reused_draft";
+type WorkingDraft = { record: RdmRecord; origin: WorkingDraftOrigin };
 
 function extractOrcid(ni: {
   nameIdentifier: string;
@@ -438,11 +570,16 @@ async function linkZenodoDeposition(
   userId: string,
   recordId: number,
   published?: { doi?: string },
+  draftOrigin?: WorkingDraftOrigin,
 ) {
   const state = {
     userId,
     depositionId: recordId,
-    status: published ? "published" : "draft",
+    status: published
+      ? "published"
+      : draftOrigin === "new_deposition"
+        ? NEW_DEPOSITION_DRAFT_STATUS
+        : "draft",
     ...(published?.doi && { lastPublishedZenodoDoi: published.doi }),
   };
 
@@ -465,6 +602,31 @@ async function linkZenodoDeposition(
 
     throw error;
   }
+}
+
+async function unlinkDraftDeposition(posterId: number, recordId: number) {
+  await prisma.zenodoDeposition.deleteMany({
+    where: {
+      posterId,
+      depositionId: recordId,
+      status: { in: ["draft", NEW_DEPOSITION_DRAFT_STATUS] },
+    },
+  });
+}
+
+async function cleanupCreatedDraft(
+  posterId: number,
+  recordId: number,
+  zenodoToken: string,
+) {
+  const discarded = await discardRdmDraft(zenodoToken, recordId);
+
+  if (!discarded.success) return discarded;
+
+  await unlinkDraftDeposition(posterId, recordId);
+  console.log(`[Zenodo] Removed failed working draft ${recordId}`);
+
+  return { success: true as const };
 }
 
 async function ensurePosterThumbnail(
@@ -674,6 +836,15 @@ export async function beginZenodoPublication(
     return { success: false, error: "Poster or metadata not found" };
   }
 
+  // Sequential local versions must extend their existing Zenodo record. Check
+  // this before thumbnail work or any remote draft can be created.
+  if (poster.versionRootId && mode !== "existing") {
+    return {
+      success: false,
+      error: "Poster versions must be published to an existing Zenodo record",
+    };
+  }
+
   const thumbnail = await ensurePosterThumbnail(
     posterInt,
     poster.extractionJob?.filePath,
@@ -686,6 +857,74 @@ export async function beginZenodoPublication(
 
   poster.imageUrl = thumbnail.imageUrl;
 
+  // Resolve the locally linked draft before acquiring anything. If Zenodo did
+  // publish it despite an ambiguous response, turn the link into the published
+  // recovery marker used below. New-deposition retries clean up drafts, while
+  // existing-deposition retries retain them for reuse.
+  if (isZenodoDraftStatus(poster.zenodoDepositions?.status)) {
+    const staleRecordId = poster.zenodoDepositions.depositionId;
+    const remoteState = await resolveZenodoRecordState(
+      tokenRecord.accessToken,
+      staleRecordId,
+    );
+
+    if (remoteState.kind === "published") {
+      const publishedDoi = extractRecordDoi(remoteState.record);
+
+      if (!publishedDoi) {
+        return {
+          success: false,
+          error: `Zenodo record ${staleRecordId} is published but its DOI could not be recovered. No new deposition was created.`,
+        };
+      }
+
+      const markedPublished = await linkZenodoDeposition(
+        posterInt,
+        userId,
+        staleRecordId,
+        { doi: publishedDoi },
+      );
+
+      if (!markedPublished.success) {
+        return { success: false, error: markedPublished.error };
+      }
+
+      poster.zenodoDepositions.status = "published";
+      poster.zenodoDepositions.lastPublishedZenodoDoi = publishedDoi;
+    } else if (remoteState.kind === "unknown") {
+      return {
+        success: false,
+        error: `${remoteState.error} The linked record was retained and no replacement was created.`,
+      };
+    } else if (
+      poster.zenodoDepositions.status === NEW_DEPOSITION_DRAFT_STATUS
+    ) {
+      const discarded = await cleanupCreatedDraft(
+        posterInt,
+        staleRecordId,
+        tokenRecord.accessToken,
+      );
+
+      if (!discarded.success) {
+        return {
+          success: false,
+          error: `${discarded.error} No new Zenodo deposition was created.`,
+        };
+      }
+
+      poster.zenodoDepositions = null;
+    } else if (remoteState.kind === "missing") {
+      await unlinkDraftDeposition(posterInt, staleRecordId);
+      poster.zenodoDepositions = null;
+    } else if (mode === "new") {
+      return {
+        success: false,
+        error:
+          "An existing Zenodo draft is already linked to this poster. Continue with that deposition instead of creating a new one.",
+      };
+    }
+  }
+
   // Zenodo may have accepted the publication even if our final local
   // transaction failed. linkZenodoDeposition is deliberately marked
   // published before that transaction, making this an idempotency marker.
@@ -693,10 +932,43 @@ export async function beginZenodoPublication(
   // unnecessary next-version draft on Zenodo.
   if (
     poster.status !== "published" &&
-    poster.zenodoDepositions?.status === "published" &&
-    poster.zenodoDepositions.lastPublishedZenodoDoi
+    poster.zenodoDepositions?.status === "published"
   ) {
-    const publishedDoi = poster.zenodoDepositions.lastPublishedZenodoDoi;
+    let publishedDoi: string | null | undefined =
+      poster.zenodoDepositions.lastPublishedZenodoDoi;
+
+    if (!publishedDoi) {
+      const remoteState = await resolveZenodoRecordState(
+        tokenRecord.accessToken,
+        poster.zenodoDepositions.depositionId,
+      );
+
+      if (remoteState.kind !== "published") {
+        return {
+          success: false,
+          error:
+            remoteState.kind === "unknown"
+              ? remoteState.error
+              : `Zenodo record ${poster.zenodoDepositions.depositionId} is marked as published locally but could not be found as a published record.`,
+        };
+      }
+
+      publishedDoi = extractRecordDoi(remoteState.record);
+
+      if (!publishedDoi) {
+        return {
+          success: false,
+          error: `Zenodo record ${poster.zenodoDepositions.depositionId} is published but its DOI could not be recovered.`,
+        };
+      }
+
+      await linkZenodoDeposition(
+        posterInt,
+        userId,
+        poster.zenodoDepositions.depositionId,
+        { doi: publishedDoi },
+      );
+    }
     const existingIdentifiers = Array.isArray(poster.posterMetadata.identifiers)
       ? (poster.posterMetadata.identifiers as PosterIdentifier[])
       : [];
@@ -827,7 +1099,8 @@ export async function beginZenodoPublication(
     return { success: false, error: status.error };
   }
 
-  const draft = status.data;
+  const workingDraft = status.data;
+  const draft = workingDraft.record;
   const recordId = Number(draft.id);
 
   if (!Number.isFinite(recordId)) {
@@ -842,26 +1115,117 @@ export async function beginZenodoPublication(
   console.log(`[Zenodo] Working draft ready - record ${recordId}`);
   console.log(`[Zenodo] Draft URL: ${draftUrl}`);
 
+  let linkedDraft = false;
+  let publishAttempted = false;
+  let publicationConfirmed = false;
+
+  const failWorkingDraft = async (error: string) => {
+    // A publish response can be lost after Zenodo commits it. Resolve that
+    // ambiguity before deciding whether a draft may be retained or deleted.
+    if (publishAttempted) {
+      const remoteState = await resolveZenodoRecordState(
+        tokenRecord.accessToken,
+        recordId,
+      );
+
+      if (remoteState.kind === "published") {
+        const publishedDoi = extractRecordDoi(remoteState.record);
+
+        if (publishedDoi) {
+          const markedPublished = await linkZenodoDeposition(
+            posterInt,
+            userId,
+            recordId,
+            { doi: publishedDoi },
+          );
+
+          if (markedPublished.success) {
+            return {
+              success: false,
+              error: `Zenodo published record ${recordId}. Retry once to finish updating the poster locally; no new deposition will be created.`,
+            };
+          }
+
+          return { success: false, error: markedPublished.error };
+        }
+
+        return {
+          success: false,
+          error: `Zenodo published record ${recordId}, but its DOI could not be recovered. No new deposition will be created.`,
+        };
+      }
+
+      if (remoteState.kind === "unknown") {
+        return {
+          success: false,
+          error: `${error} Zenodo could not confirm whether record ${recordId} was published, so the linked record was retained and no replacement should be created. ${remoteState.error}`,
+        };
+      }
+
+      if (remoteState.kind === "missing") {
+        return {
+          success: false,
+          error: `${error} Zenodo could not find record ${recordId} immediately after the publish attempt, so its local checkpoint was retained. Retry to resolve it before creating another deposition.`,
+        };
+      }
+
+      if (publicationConfirmed) {
+        return {
+          success: false,
+          error: `${error} Zenodo accepted the publish request, so record ${recordId} was retained for reconciliation and no replacement should be created.`,
+        };
+      }
+    }
+
+    const shouldCleanup =
+      workingDraft.origin === "new_deposition" ||
+      (!linkedDraft && workingDraft.origin === "new_version");
+
+    if (!shouldCleanup) return { success: false, error };
+
+    const cleanup = await cleanupCreatedDraft(
+      posterInt,
+      recordId,
+      tokenRecord.accessToken,
+    );
+
+    if (cleanup.success) return { success: false, error };
+
+    return {
+      success: false,
+      error: `${error} Zenodo draft ${recordId} could not be removed, so it was retained for a safe retry. ${cleanup.error}`,
+    };
+  };
+
   // Persist the working draft before any subsequent network operation. If a
   // purge, metadata update, or upload fails, the next attempt can resume this
   // exact draft instead of asking Zenodo to create another version.
-  const linked = await linkZenodoDeposition(posterInt, userId, recordId);
+  let linked;
+
+  try {
+    linked = await linkZenodoDeposition(
+      posterInt,
+      userId,
+      recordId,
+      undefined,
+      workingDraft.origin,
+    );
+  } catch (error) {
+    return failWorkingDraft(
+      `Could not save Zenodo draft ${recordId}: ${(error as Error).message}`,
+    );
+  }
 
   if (!linked.success) {
-    return { success: false, error: linked.error };
+    return failWorkingDraft(linked.error);
   }
 
-  if (poster.versionRootId && mode !== "existing") {
-    return {
-      success: false,
-      error: "Poster versions must be published to an existing Zenodo record",
-    };
-  }
+  linkedDraft = true;
 
   const purged = await purgeDraftFiles(recordId, tokenRecord.accessToken);
 
   if (!purged.success) {
-    return { success: false, error: purged.error };
+    return failWorkingDraft(purged.error);
   }
 
   await onProgress?.({
@@ -890,10 +1254,16 @@ export async function beginZenodoPublication(
   if (Object.keys(metadataUpdates).length > 0) {
     console.log("[Zenodo] Saving publication metadata choices");
 
-    await prisma.posterMetadata.update({
-      where: { posterId: posterInt },
-      data: metadataUpdates,
-    });
+    try {
+      await prisma.posterMetadata.update({
+        where: { posterId: posterInt },
+        data: metadataUpdates,
+      });
+    } catch (error) {
+      return failWorkingDraft(
+        `Could not save publication metadata: ${(error as Error).message}`,
+      );
+    }
 
     if (license) poster.posterMetadata.license = license;
     if (!poster.automated && requestedVersion) {
@@ -1043,7 +1413,9 @@ export async function beginZenodoPublication(
       message: `Metadata update failed: ${metadataResult.error}`,
     });
 
-    return { success: false, error: metadataResult.error };
+    return failWorkingDraft(
+      metadataResult.error ?? "Zenodo rejected the poster metadata",
+    );
   }
 
   // Reserved after the metadata PUT because that PUT replaces the whole record.
@@ -1060,7 +1432,7 @@ export async function beginZenodoPublication(
       message: reserved.error,
     });
 
-    return { success: false, error: reserved.error };
+    return failWorkingDraft(reserved.error);
   }
 
   const doi = reserved.doi;
@@ -1081,13 +1453,21 @@ export async function beginZenodoPublication(
   // Build poster.json from DB data and upload it to the draft
   console.log(`[Zenodo] Building poster.json for poster: ${posterId}`);
 
-  const posterJson = buildPosterJson(poster.posterMetadata, {
-    title: poster.title,
-    description: poster.description,
-    zenodoDoi: doi,
-    publishedAt: zenodoSharedAt,
-    includePublisher: true,
-  });
+  let posterJson;
+
+  try {
+    posterJson = buildPosterJson(poster.posterMetadata, {
+      title: poster.title,
+      description: poster.description,
+      zenodoDoi: doi,
+      publishedAt: zenodoSharedAt,
+      includePublisher: true,
+    });
+  } catch (error) {
+    return failWorkingDraft(
+      `Could not build poster metadata package: ${(error as Error).message}`,
+    );
+  }
   const posterJsonEncoded = new TextEncoder().encode(
     JSON.stringify(posterJson, null, 2),
   );
@@ -1108,20 +1488,30 @@ export async function beginZenodoPublication(
   if (!uploadResult.success) {
     console.log(`[Zenodo] Failed to upload poster.json: ${uploadResult.error}`);
 
-    return { success: false, error: uploadResult.error };
+    return failWorkingDraft(
+      uploadResult.error ?? "Failed to upload poster.json",
+    );
   }
 
   // Retrieve and upload poster file
-  const extractionJob = await prisma.extractionJob.findUnique({
-    where: { posterId: posterInt },
-  });
+  let extractionJob;
+
+  try {
+    extractionJob = await prisma.extractionJob.findUnique({
+      where: { posterId: posterInt },
+    });
+  } catch (error) {
+    return failWorkingDraft(
+      `Could not load the poster file: ${(error as Error).message}`,
+    );
+  }
 
   if (!extractionJob?.filePath) {
     console.log(
       `[Zenodo] No extraction job or file path found for poster: ${posterId}`,
     );
 
-    return { success: false, error: "Poster file not found for upload" };
+    return failWorkingDraft("Poster file not found for upload");
   }
 
   const posterFileName = sanitizeZenodoFileKey(
@@ -1164,7 +1554,9 @@ export async function beginZenodoPublication(
       `[Zenodo] Failed to upload poster file "${posterFileName}": ${posterFileUpload.error}`,
     );
 
-    return { success: false, error: posterFileUpload.error };
+    return failWorkingDraft(
+      posterFileUpload.error ?? `Failed to upload ${posterFileName}`,
+    );
   }
 
   console.log(`[Zenodo] Uploaded poster file "${posterFileName}" successfully`);
@@ -1186,6 +1578,7 @@ export async function beginZenodoPublication(
   console.log(`[Zenodo] About to publish record: ${recordId}`);
   console.log(`[Zenodo] Inspect draft before publish: ${draftUrl}`);
 
+  publishAttempted = true;
   const publishResult = await publishRdmDraft(
     tokenRecord.accessToken,
     recordId,
@@ -1194,23 +1587,39 @@ export async function beginZenodoPublication(
   if (!publishResult.success) {
     console.log(`[Zenodo] Publication failed [record ${recordId}]`);
 
-    return { success: false, error: publishResult.error };
+    return failWorkingDraft(publishResult.error);
   }
 
   const published = publishResult.data;
-  const publishedDoi = published.doi;
+  publicationConfirmed = true;
+  let publishedDoi = published.doi;
 
   // A record without a DOI would otherwise leave a publicly published poster with no identifier.
   if (!publishedDoi) {
-    console.error(
-      `[Zenodo] Published record ${published.recordId} is missing a DOI in the response`,
+    const remoteState = await resolveZenodoRecordState(
+      tokenRecord.accessToken,
+      published.recordId,
     );
 
-    return {
-      success: false,
-      error: `Zenodo published record ${published.recordId} but returned no DOI`,
-    };
+    if (remoteState.kind === "published") {
+      publishedDoi = extractRecordDoi(remoteState.record);
+    }
+
+    if (!publishedDoi) {
+      await linkZenodoDeposition(posterInt, userId, published.recordId, {});
+
+      console.error(
+        `[Zenodo] Published record ${published.recordId} is missing a recoverable DOI`,
+      );
+
+      return {
+        success: false,
+        error: `Zenodo published record ${published.recordId} but its DOI could not be recovered. No new deposition will be created.`,
+      };
+    }
   }
+
+  published.doi = publishedDoi;
 
   const linkedPublished = await linkZenodoDeposition(
     posterInt,
@@ -1451,10 +1860,17 @@ async function acquireWorkingDraft(
   zenodoToken: string,
   seed: RdmDraftSeed,
 ): Promise<
-  { success: true; data: RdmRecord } | { success: false; error: string }
+  { success: true; data: WorkingDraft } | { success: false; error: string }
 > {
   if (mode === "new") {
-    return createRdmDraft(zenodoToken, seed);
+    const created = await createRdmDraft(zenodoToken, seed);
+
+    return created.success
+      ? {
+          success: true,
+          data: { record: created.data, origin: "new_deposition" },
+        }
+      : created;
   }
 
   console.log(`[Zenodo] Resolving existing Zenodo record: ${depositionId}`);
@@ -1508,7 +1924,14 @@ async function acquireWorkingDraft(
       `[Zenodo] Record ${depositionId} is published, creating a new version from ${latestId}`,
     );
 
-    return createRdmVersion(zenodoToken, latestId);
+    const created = await createRdmVersion(zenodoToken, latestId);
+
+    return created.success
+      ? {
+          success: true,
+          data: { record: created.data, origin: "new_version" },
+        }
+      : created;
   }
 
   if (published.status === 404) {
@@ -1520,7 +1943,13 @@ async function acquireWorkingDraft(
         `[Zenodo] Record ${depositionId} is an unpublished draft, reusing it`,
       );
 
-      return { success: true, data: (await draft.json()) as RdmRecord };
+      return {
+        success: true,
+        data: {
+          record: (await draft.json()) as RdmRecord,
+          origin: "reused_draft",
+        },
+      };
     }
 
     if (draft.status === 404) {

--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -16,6 +16,15 @@ const MAX_LOGGED_BODY = 1000;
 // abstracts), so they are only logged when running locally.
 const logFullPayloads = config.siteEnv === "development";
 
+type FundingReference = {
+  funderName?: string;
+  funderIdentifier?: string;
+  funderIdentifierType?: string;
+  awardNumber?: string;
+  awardUri?: string;
+  awardTitle?: string;
+};
+
 function truncateForLog(body: string): string {
   return body.length > MAX_LOGGED_BODY
     ? `${body.slice(0, MAX_LOGGED_BODY)}… (${body.length} bytes total)`
@@ -326,6 +335,51 @@ async function refreshZenodoToken(userId: string, refreshToken: string) {
   }
 }
 
+/**
+ * Discards an unpublished InvenioRDM draft that is linked to a local poster.
+ * A missing draft is already in the desired state, so retries remain safe.
+ */
+export async function discardZenodoDraft(userId: string, recordId: number) {
+  const tokenRecord = await getZenodoToken(userId);
+
+  if (!tokenRecord) {
+    return {
+      success: false as const,
+      error:
+        "Reconnect your Zenodo account before deleting this version draft.",
+    };
+  }
+
+  let response: Response;
+
+  try {
+    response = await fetch(
+      `${config.zenodoApiEndpoint}/records/${recordId}/draft`,
+      {
+        method: "DELETE",
+        headers: rdmHeaders(tokenRecord.accessToken),
+      },
+    );
+  } catch (error) {
+    return {
+      success: false as const,
+      error: `Could not reach Zenodo while deleting draft ${recordId}: ${(error as Error).message}`,
+    };
+  }
+
+  if (response.ok || response.status === 404) {
+    return { success: true as const };
+  }
+
+  return {
+    success: false as const,
+    error: await getZenodoErrorMessage(
+      `Failed to delete Zenodo draft ${recordId}`,
+      response,
+    ),
+  };
+}
+
 export type PublicationProgressEvent = {
   step: string;
   status: "in_progress" | "completed" | "error";
@@ -419,15 +473,6 @@ export async function beginZenodoPublication(
     `[Zenodo] Beginning publication for poster: ${posterId}, mode: ${mode}, depositionId: ${existingDepositionId}`,
   );
 
-  if (mode === "existing" && !existingDepositionId) {
-    console.log("[Zenodo] Missing deposition ID for existing mode");
-
-    return {
-      success: false,
-      error: "Existing deposition ID is required for 'existing' mode",
-    };
-  }
-
   // Get the user's Zenodo token
   const tokenRecord = await getZenodoToken(userId);
 
@@ -451,8 +496,8 @@ export async function beginZenodoPublication(
   console.log(`[Zenodo] Fetching poster and metadata for: ${posterId}`);
 
   const poster = await prisma.poster.findUnique({
-    where: { id: posterInt },
-    include: { posterMetadata: true },
+    where: { id: posterInt, userId },
+    include: { posterMetadata: true, zenodoDepositions: true },
   });
 
   if (!poster || !poster.posterMetadata) {
@@ -461,11 +506,59 @@ export async function beginZenodoPublication(
     return { success: false, error: "Poster or metadata not found" };
   }
 
+  const rawFunding = Array.isArray(poster.posterMetadata.fundingReferences)
+    ? (poster.posterMetadata.fundingReferences as FundingReference[])
+    : [];
+  const incompleteAwardIndex = rawFunding.findIndex(
+    (funding) =>
+      !!funding.awardUri?.trim() &&
+      !funding.awardNumber?.trim() &&
+      !funding.awardTitle?.trim(),
+  );
+
+  if (incompleteAwardIndex >= 0) {
+    return {
+      success: false,
+      error: `Funding reference ${incompleteAwardIndex + 1}: Award title or award number is required when an award URI is provided. Review the poster metadata before publishing.`,
+    };
+  }
+
+  let effectiveDepositionId = existingDepositionId;
+
+  // A retry should resume the draft already linked to this local version. For
+  // a brand-new local version, fall back to the latest published predecessor's
+  // stored record so callers do not have to rediscover it client-side.
+  if (mode === "existing" && poster.zenodoDepositions?.status === "draft") {
+    effectiveDepositionId = poster.zenodoDepositions.depositionId;
+  } else if (
+    mode === "existing" &&
+    !effectiveDepositionId &&
+    poster.versionRootId
+  ) {
+    const predecessor = await prisma.poster.findFirst({
+      where: {
+        status: "published",
+        versionSequence: { lt: poster.versionSequence },
+        ...posterFamilyWhere(poster.versionRootId),
+      },
+      orderBy: { versionSequence: "desc" },
+      select: { zenodoDepositions: { select: { depositionId: true } } },
+    });
+    effectiveDepositionId = predecessor?.zenodoDepositions?.depositionId;
+  }
+
+  if (mode === "existing" && !effectiveDepositionId) {
+    return {
+      success: false,
+      error: "An existing Zenodo record is required for this version",
+    };
+  }
+
   console.log("[Zenodo] Acquiring working draft");
 
   const status = await acquireWorkingDraft(
     mode,
-    existingDepositionId,
+    effectiveDepositionId,
     tokenRecord.accessToken,
     {
       title: poster.title,
@@ -499,16 +592,84 @@ export async function beginZenodoPublication(
   console.log(`[Zenodo] Working draft ready - record ${recordId}`);
   console.log(`[Zenodo] Draft URL: ${draftUrl}`);
 
-  const purged = await purgeDraftFiles(recordId, tokenRecord.accessToken);
-
-  if (!purged.success) {
-    return { success: false, error: purged.error };
-  }
-
+  // Persist the working draft before any subsequent network operation. If a
+  // purge, metadata update, or upload fails, the next attempt can resume this
+  // exact draft instead of asking Zenodo to create another version.
   const linked = await linkZenodoDeposition(posterInt, userId, recordId);
 
   if (!linked.success) {
     return { success: false, error: linked.error };
+  }
+
+  // Zenodo publication happens before the final local transaction. If that
+  // transaction failed on an earlier attempt, the deposition row still tells
+  // us exactly which DOI was published; reconcile locally instead of creating
+  // yet another Zenodo version.
+  if (
+    poster.status !== "published" &&
+    poster.zenodoDepositions?.status === "published" &&
+    poster.zenodoDepositions.lastPublishedZenodoDoi
+  ) {
+    const publishedDoi = poster.zenodoDepositions.lastPublishedZenodoDoi;
+    const existingIdentifiers = Array.isArray(poster.posterMetadata.identifiers)
+      ? (poster.posterMetadata.identifiers as PosterIdentifier[])
+      : [];
+    const identifiers = existingIdentifiers.some(
+      (identifier) =>
+        identifier.identifier === publishedDoi &&
+        identifier.identifierType === "DOI",
+    )
+      ? existingIdentifiers
+      : [
+          { identifier: publishedDoi, identifierType: "DOI" },
+          ...existingIdentifiers,
+        ];
+    const rootId = posterFamilyRootId(poster);
+
+    await prisma.$transaction([
+      prisma.poster.updateMany({
+        where: posterFamilyWhere(rootId),
+        data: { isLatestVersion: false },
+      }),
+      prisma.poster.update({
+        where: { id: poster.id },
+        data: {
+          status: "published",
+          publishedAt: new Date(),
+          isLatestVersion: true,
+        },
+      }),
+      prisma.posterMetadata.update({
+        where: { posterId: poster.id },
+        data: {
+          doi: publishedDoi,
+          publisher: "Zenodo",
+          identifiers,
+        },
+      }),
+    ]);
+
+    return {
+      success: true,
+      data: {
+        recordId: poster.zenodoDepositions.depositionId,
+        doi: publishedDoi,
+        recordUrl: `${config.zenodoEndpoint}/records/${poster.zenodoDepositions.depositionId}`,
+      },
+    };
+  }
+
+  if (poster.versionRootId && mode !== "existing") {
+    return {
+      success: false,
+      error: "Poster versions must be published to an existing Zenodo record",
+    };
+  }
+
+  const purged = await purgeDraftFiles(recordId, tokenRecord.accessToken);
+
+  if (!purged.success) {
+    return { success: false, error: purged.error };
   }
 
   await onProgress?.({
@@ -587,15 +748,6 @@ export async function beginZenodoPublication(
     resourceTypeGeneral?: string;
   }[];
 
-  const rawFunding = meta.fundingReferences as {
-    funderName?: string;
-    funderIdentifier?: string;
-    funderIdentifierType?: string;
-    awardNumber?: string;
-    awardUri?: string;
-    awardTitle?: string;
-  }[];
-
   const datesArr = Array.isArray(meta.dates)
     ? (meta.dates as Array<{ date?: string; dateType?: string }>)
     : [];
@@ -645,13 +797,8 @@ export async function beginZenodoPublication(
   // Bump the version before the metadata PUT: `meta` is passed by reference
   // into the payload builder, so bumping afterwards would send Zenodo the old
   // version while the DB recorded the new one.
-  if (!meta.version) {
-    meta.version = mode === "new" ? "1" : null;
-  } else if (mode === "existing") {
-    const prev = parseInt(meta.version as string, 10);
-    if (!isNaN(prev)) {
-      meta.version = String(prev + 1);
-    }
+  if (!poster.automated) {
+    meta.version = posterVersionLabel(poster.versionSequence);
   }
 
   console.log(`[Zenodo] Updating metadata via InvenioRDM [record ${recordId}]`);
@@ -937,15 +1084,6 @@ export async function beginZenodoPublication(
     }
   }
 
-  await prisma.poster.update({
-    where: { id: posterInt },
-    data: {
-      status: "published",
-      publishedAt: new Date(),
-      ...(newImageUrl && { imageUrl: newImageUrl }),
-    },
-  });
-
   const alreadyHasDoi = metaIdentifiers.some(
     (i) => i.identifier === publishedDoi && i.identifierType === "DOI",
   );
@@ -953,15 +1091,31 @@ export async function beginZenodoPublication(
     ? metaIdentifiers
     : [{ identifier: publishedDoi, identifierType: "DOI" }, ...metaIdentifiers];
 
-  await prisma.posterMetadata.update({
-    where: { posterId: posterInt },
-    data: {
-      doi: publishedDoi,
-      publisher: "Zenodo",
-      identifiers: updatedIdentifiers,
-      ...(meta.version && { version: meta.version }),
-    },
-  });
+  const familyRootId = posterFamilyRootId(poster);
+  await prisma.$transaction([
+    prisma.poster.updateMany({
+      where: posterFamilyWhere(familyRootId),
+      data: { isLatestVersion: false },
+    }),
+    prisma.poster.update({
+      where: { id: posterInt },
+      data: {
+        status: "published",
+        publishedAt: new Date(),
+        isLatestVersion: true,
+        ...(newImageUrl && { imageUrl: newImageUrl }),
+      },
+    }),
+    prisma.posterMetadata.update({
+      where: { posterId: posterInt },
+      data: {
+        doi: publishedDoi,
+        publisher: "Zenodo",
+        identifiers: updatedIdentifiers,
+        ...(meta.version && { version: meta.version }),
+      },
+    }),
+  ]);
 
   await onProgress?.({
     step: "publish",
@@ -1495,14 +1649,7 @@ type RdmExtras = {
   skipRorIds?: boolean;
   skipFunderIds?: boolean;
   submissionAbstract?: string;
-  rawFunding?: {
-    funderName?: string;
-    funderIdentifier?: string;
-    funderIdentifierType?: string;
-    awardNumber?: string;
-    awardUri?: string;
-    awardTitle?: string;
-  }[];
+  rawFunding?: FundingReference[];
   dbRelated?: {
     relatedIdentifier?: string;
     relatedIdentifierType?: string;
@@ -1578,7 +1725,7 @@ function buildFullRdmPayload(
       const entry: Record<string, unknown> = {
         funder: { name: f.funderName, ...(rorId && { id: rorId }) },
       };
-      if (f.awardNumber?.trim() || f.awardUri?.trim()) {
+      if (f.awardNumber?.trim() || f.awardTitle?.trim()) {
         entry.award = {
           ...(f.awardNumber?.trim() && { number: f.awardNumber }),
           ...(f.awardTitle?.trim() && { title: { en: f.awardTitle } }),

--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -506,6 +506,69 @@ export async function beginZenodoPublication(
     return { success: false, error: "Poster or metadata not found" };
   }
 
+  // Zenodo may have accepted the publication even if our final local
+  // transaction failed. linkZenodoDeposition is deliberately marked
+  // published before that transaction, making this an idempotency marker.
+  // Reconcile it before acquiring a working draft so a retry cannot create an
+  // unnecessary next-version draft on Zenodo.
+  if (
+    poster.status !== "published" &&
+    poster.zenodoDepositions?.status === "published" &&
+    poster.zenodoDepositions.lastPublishedZenodoDoi
+  ) {
+    const publishedDoi = poster.zenodoDepositions.lastPublishedZenodoDoi;
+    const existingIdentifiers = Array.isArray(poster.posterMetadata.identifiers)
+      ? (poster.posterMetadata.identifiers as PosterIdentifier[])
+      : [];
+    const identifiers = existingIdentifiers.some(
+      (identifier) =>
+        identifier.identifier === publishedDoi &&
+        identifier.identifierType === "DOI",
+    )
+      ? existingIdentifiers
+      : [
+          { identifier: publishedDoi, identifierType: "DOI" },
+          ...existingIdentifiers,
+        ];
+    const rootId = posterFamilyRootId(poster);
+
+    console.log(
+      `[Zenodo] Reconciling local poster from published record ${poster.zenodoDepositions.depositionId}`,
+    );
+
+    await prisma.$transaction([
+      prisma.poster.updateMany({
+        where: posterFamilyWhere(rootId),
+        data: { isLatestVersion: false },
+      }),
+      prisma.poster.update({
+        where: { id: poster.id },
+        data: {
+          status: "published",
+          publishedAt: new Date(),
+          isLatestVersion: true,
+        },
+      }),
+      prisma.posterMetadata.update({
+        where: { posterId: poster.id },
+        data: {
+          doi: publishedDoi,
+          publisher: "Zenodo",
+          identifiers,
+        },
+      }),
+    ]);
+
+    return {
+      success: true,
+      data: {
+        recordId: poster.zenodoDepositions.depositionId,
+        doi: publishedDoi,
+        recordUrl: `${config.zenodoEndpoint}/records/${poster.zenodoDepositions.depositionId}`,
+      },
+    };
+  }
+
   const rawFunding = Array.isArray(poster.posterMetadata.fundingReferences)
     ? (poster.posterMetadata.fundingReferences as FundingReference[])
     : [];
@@ -599,64 +662,6 @@ export async function beginZenodoPublication(
 
   if (!linked.success) {
     return { success: false, error: linked.error };
-  }
-
-  // Zenodo publication happens before the final local transaction. If that
-  // transaction failed on an earlier attempt, the deposition row still tells
-  // us exactly which DOI was published; reconcile locally instead of creating
-  // yet another Zenodo version.
-  if (
-    poster.status !== "published" &&
-    poster.zenodoDepositions?.status === "published" &&
-    poster.zenodoDepositions.lastPublishedZenodoDoi
-  ) {
-    const publishedDoi = poster.zenodoDepositions.lastPublishedZenodoDoi;
-    const existingIdentifiers = Array.isArray(poster.posterMetadata.identifiers)
-      ? (poster.posterMetadata.identifiers as PosterIdentifier[])
-      : [];
-    const identifiers = existingIdentifiers.some(
-      (identifier) =>
-        identifier.identifier === publishedDoi &&
-        identifier.identifierType === "DOI",
-    )
-      ? existingIdentifiers
-      : [
-          { identifier: publishedDoi, identifierType: "DOI" },
-          ...existingIdentifiers,
-        ];
-    const rootId = posterFamilyRootId(poster);
-
-    await prisma.$transaction([
-      prisma.poster.updateMany({
-        where: posterFamilyWhere(rootId),
-        data: { isLatestVersion: false },
-      }),
-      prisma.poster.update({
-        where: { id: poster.id },
-        data: {
-          status: "published",
-          publishedAt: new Date(),
-          isLatestVersion: true,
-        },
-      }),
-      prisma.posterMetadata.update({
-        where: { posterId: poster.id },
-        data: {
-          doi: publishedDoi,
-          publisher: "Zenodo",
-          identifiers,
-        },
-      }),
-    ]);
-
-    return {
-      success: true,
-      data: {
-        recordId: poster.zenodoDepositions.depositionId,
-        doi: publishedDoi,
-        recordUrl: `${config.zenodoEndpoint}/records/${poster.zenodoDepositions.depositionId}`,
-      },
-    };
   }
 
   if (poster.versionRootId && mode !== "existing") {

--- a/server/utils/zenodo.ts
+++ b/server/utils/zenodo.ts
@@ -169,6 +169,8 @@ export type ZenodoUserRecord = {
   title: string;
   isPublished: boolean;
   conceptDoi?: string;
+  version?: string;
+  versionIndex?: number;
 };
 
 // Maps an InvenioRDM /user/records search body to the shape of the publish UI
@@ -182,12 +184,16 @@ function parseUserRecords(body: unknown): ZenodoUserRecord[] {
     if (!Number.isFinite(id)) continue;
 
     const conceptDoi = extractConceptDoi(hit);
+    const version = hit.metadata?.version?.trim();
+    const versionIndex = hit.versions?.index;
 
     records.push({
       id,
       title: hit.metadata?.title ?? "Untitled deposit",
       isPublished: extractIsPublished(hit),
       ...(conceptDoi && { conceptDoi }),
+      ...(version && { version }),
+      ...(Number.isInteger(versionIndex) && { versionIndex }),
     });
   }
 
@@ -461,6 +467,163 @@ async function linkZenodoDeposition(
   }
 }
 
+async function ensurePosterThumbnail(
+  posterId: number,
+  filePath: string | null | undefined,
+  currentImageUrl: string,
+) {
+  if (currentImageUrl) {
+    return { success: true as const, imageUrl: currentImageUrl };
+  }
+
+  if (!filePath) {
+    return {
+      success: false as const,
+      error: "Poster file not found while preparing its thumbnail",
+    };
+  }
+
+  if (!config.posterExtractionApi) {
+    return {
+      success: false as const,
+      error: "Poster thumbnail service is not configured",
+    };
+  }
+
+  console.log(`[Zenodo] Generating missing thumbnail for poster ${posterId}`);
+
+  const response = await fetch(
+    `${config.posterExtractionApi}/thumbnails/generate`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pdf_path: filePath, poster_id: posterId }),
+    },
+  );
+
+  if (!response.ok) {
+    const detail = truncateForLog(await response.text().catch(() => ""));
+
+    console.error(
+      `[Zenodo] Thumbnail generation failed for poster ${posterId}: ${response.status} ${detail}`,
+    );
+
+    return {
+      success: false as const,
+      error: "Could not generate the poster thumbnail. Please try again.",
+    };
+  }
+
+  // The extraction service writes imageUrl back to the poster. It may respond
+  // before that database update is visible, so briefly wait for the callback.
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const refreshed = await prisma.poster.findUnique({
+      where: { id: posterId },
+      select: { imageUrl: true },
+    });
+
+    if (refreshed?.imageUrl) {
+      return { success: true as const, imageUrl: refreshed.imageUrl };
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  return {
+    success: false as const,
+    error:
+      "The poster thumbnail is still being prepared. Please try publishing again shortly.",
+  };
+}
+
+async function promotePosterThumbnail(imageUrl: string) {
+  const {
+    bunnyPrivateStorage,
+    bunnyPrivateStorageKey,
+    bunnyPublicStorage,
+    bunnyPublicStorageKey,
+  } = config;
+
+  if (!imageUrl) {
+    return {
+      success: false as const,
+      error: "Poster thumbnail is missing",
+    };
+  }
+
+  // Reused thumbnails and external poster images may already be public.
+  if (!bunnyPrivateStorage || !imageUrl.startsWith(bunnyPrivateStorage)) {
+    return { success: true as const, imageUrl };
+  }
+
+  if (
+    !bunnyPrivateStorageKey ||
+    !bunnyPublicStorage ||
+    !bunnyPublicStorageKey
+  ) {
+    return {
+      success: false as const,
+      error: "Poster thumbnail storage is not configured",
+    };
+  }
+
+  const thumbnailPath = imageUrl
+    .slice(bunnyPrivateStorage.length)
+    .replace(/^\//, "");
+
+  try {
+    const downloadRes = await fetch(`${bunnyPrivateStorage}/${thumbnailPath}`, {
+      headers: { AccessKey: bunnyPrivateStorageKey },
+    });
+
+    if (!downloadRes.ok) {
+      console.error(
+        `[Zenodo] Failed to download thumbnail from private storage: ${downloadRes.status}`,
+      );
+
+      return {
+        success: false as const,
+        error: "Could not retrieve the poster thumbnail from storage",
+      };
+    }
+
+    const contentType = downloadRes.headers.get("Content-Type") ?? "image/jpeg";
+    const fileBuffer = await downloadRes.arrayBuffer();
+    const uploadRes = await fetch(`${bunnyPublicStorage}/${thumbnailPath}`, {
+      method: "PUT",
+      headers: {
+        AccessKey: bunnyPublicStorageKey,
+        "Content-Type": contentType,
+        "Content-Length": String(fileBuffer.byteLength),
+      },
+      body: fileBuffer,
+    });
+
+    if (!uploadRes.ok) {
+      console.error(
+        `[Zenodo] Failed to upload thumbnail to public storage: ${uploadRes.status}`,
+      );
+
+      return {
+        success: false as const,
+        error: "Could not publish the poster thumbnail",
+      };
+    }
+
+    return {
+      success: true as const,
+      imageUrl: `https://cdn.posters.science/${thumbnailPath}`,
+    };
+  } catch (error) {
+    console.error("[Zenodo] Error publishing thumbnail:", error);
+
+    return {
+      success: false as const,
+      error: "Could not publish the poster thumbnail",
+    };
+  }
+}
+
 export async function beginZenodoPublication(
   posterId: string,
   mode: string,
@@ -468,6 +631,7 @@ export async function beginZenodoPublication(
   userId: string,
   onProgress?: ProgressCallback,
   license?: string,
+  version?: string,
 ) {
   console.log(
     `[Zenodo] Beginning publication for poster: ${posterId}, mode: ${mode}, depositionId: ${existingDepositionId}`,
@@ -497,7 +661,11 @@ export async function beginZenodoPublication(
 
   const poster = await prisma.poster.findUnique({
     where: { id: posterInt, userId },
-    include: { posterMetadata: true, zenodoDepositions: true },
+    include: {
+      posterMetadata: true,
+      zenodoDepositions: true,
+      extractionJob: { select: { filePath: true } },
+    },
   });
 
   if (!poster || !poster.posterMetadata) {
@@ -505,6 +673,18 @@ export async function beginZenodoPublication(
 
     return { success: false, error: "Poster or metadata not found" };
   }
+
+  const thumbnail = await ensurePosterThumbnail(
+    posterInt,
+    poster.extractionJob?.filePath,
+    poster.imageUrl,
+  );
+
+  if (!thumbnail.success) {
+    return { success: false, error: thumbnail.error };
+  }
+
+  poster.imageUrl = thumbnail.imageUrl;
 
   // Zenodo may have accepted the publication even if our final local
   // transaction failed. linkZenodoDeposition is deliberately marked
@@ -536,6 +716,12 @@ export async function beginZenodoPublication(
       `[Zenodo] Reconciling local poster from published record ${poster.zenodoDepositions.depositionId}`,
     );
 
+    const recoveredThumbnail = await promotePosterThumbnail(poster.imageUrl);
+
+    if (!recoveredThumbnail.success) {
+      return { success: false, error: recoveredThumbnail.error };
+    }
+
     await prisma.$transaction([
       prisma.poster.updateMany({
         where: posterFamilyWhere(rootId),
@@ -547,6 +733,7 @@ export async function beginZenodoPublication(
           status: "published",
           publishedAt: new Date(),
           isLatestVersion: true,
+          imageUrl: recoveredThumbnail.imageUrl,
         },
       }),
       prisma.posterMetadata.update({
@@ -690,16 +877,28 @@ export async function beginZenodoPublication(
     message: "Loading poster data...",
   });
 
-  // Persist license to DB if provided so poster.json and the record stay in sync
-  if (license) {
-    console.log(`[Zenodo] Saving license to posterMetadata: ${license}`);
+  // If a user types "v2", remove
+  // the "v" prefix so Zenodo receives "2".
+  const requestedVersion = version?.trim().replace(/^v(?=\d)/i, "");
+  const metadataUpdates = {
+    ...(license && { license }),
+    ...(!poster.automated && requestedVersion && { version: requestedVersion }),
+  };
+
+  // Persist publication choices before creating poster.json so the local
+  // package, Zenodo metadata, and a resumed attempt all use the same values.
+  if (Object.keys(metadataUpdates).length > 0) {
+    console.log("[Zenodo] Saving publication metadata choices");
 
     await prisma.posterMetadata.update({
       where: { posterId: posterInt },
-      data: { license },
+      data: metadataUpdates,
     });
 
-    poster.posterMetadata.license = license;
+    if (license) poster.posterMetadata.license = license;
+    if (!poster.automated && requestedVersion) {
+      poster.posterMetadata.version = requestedVersion;
+    }
   }
 
   await onProgress?.({
@@ -799,11 +998,14 @@ export async function beginZenodoPublication(
     submissionAbstract?: string;
   } | null;
 
-  // Bump the version before the metadata PUT: `meta` is passed by reference
-  // into the payload builder, so bumping afterwards would send Zenodo the old
-  // version while the DB recorded the new one.
+  // Older callers may not send an explicit version. Preserve the existing
+  // sequence-based fallback for those requests, while respecting the value the
+  // user selected in the publish form.
   if (!poster.automated) {
-    meta.version = posterVersionLabel(poster.versionSequence);
+    meta.version =
+      requestedVersion ||
+      meta.version?.trim() ||
+      posterVersionLabel(poster.versionSequence);
   }
 
   console.log(`[Zenodo] Updating metadata via InvenioRDM [record ${recordId}]`);
@@ -1021,72 +1223,12 @@ export async function beginZenodoPublication(
     return { success: false, error: linkedPublished.error };
   }
 
-  // Move the thumbnail from private to public storage now the record is live
-  const posterWithImage = await prisma.poster.findUnique({
-    where: { id: posterInt },
-    select: { imageUrl: true },
-  });
+  // Move a newly generated private thumbnail to public storage. Reused images
+  // are already public and pass through unchanged.
+  const publishedThumbnail = await promotePosterThumbnail(poster.imageUrl);
 
-  let newImageUrl: string | undefined;
-
-  const {
-    bunnyPrivateStorage,
-    bunnyPrivateStorageKey,
-    bunnyPublicStorage,
-    bunnyPublicStorageKey,
-  } = config;
-
-  const imageUrl = posterWithImage?.imageUrl;
-  if (
-    imageUrl &&
-    bunnyPrivateStorage &&
-    imageUrl.startsWith(bunnyPrivateStorage)
-  ) {
-    const thumbnailPath = imageUrl
-      .slice(bunnyPrivateStorage.length)
-      .replace(/^\//, "");
-
-    if (bunnyPrivateStorageKey && bunnyPublicStorage && bunnyPublicStorageKey) {
-      try {
-        const downloadRes = await fetch(
-          `${bunnyPrivateStorage}/${thumbnailPath}`,
-          { headers: { AccessKey: bunnyPrivateStorageKey } },
-        );
-
-        if (downloadRes.ok) {
-          const contentType =
-            downloadRes.headers.get("Content-Type") ?? "image/jpeg";
-          const fileBuffer = await downloadRes.arrayBuffer();
-
-          const uploadRes = await fetch(
-            `${bunnyPublicStorage}/${thumbnailPath}`,
-            {
-              method: "PUT",
-              headers: {
-                AccessKey: bunnyPublicStorageKey,
-                "Content-Type": contentType,
-                "Content-Length": String(fileBuffer.byteLength),
-              },
-              body: fileBuffer,
-            },
-          );
-
-          if (uploadRes.ok) {
-            newImageUrl = `https://cdn.posters.science/${thumbnailPath}`;
-          } else {
-            console.error(
-              `[Zenodo] Failed to upload thumbnail to public storage: ${uploadRes.status}`,
-            );
-          }
-        } else {
-          console.error(
-            `[Zenodo] Failed to download thumbnail from private storage: ${downloadRes.status}`,
-          );
-        }
-      } catch (err) {
-        console.error("[Zenodo] Error moving thumbnail:", err);
-      }
-    }
+  if (!publishedThumbnail.success) {
+    return { success: false, error: publishedThumbnail.error };
   }
 
   const alreadyHasDoi = metaIdentifiers.some(
@@ -1108,7 +1250,7 @@ export async function beginZenodoPublication(
         status: "published",
         publishedAt: new Date(),
         isLatestVersion: true,
-        ...(newImageUrl && { imageUrl: newImageUrl }),
+        imageUrl: publishedThumbnail.imageUrl,
       },
     }),
     prisma.posterMetadata.update({
@@ -1164,7 +1306,7 @@ type RdmRecord = {
   conceptrecid?: string | number;
   submitted?: boolean;
   state?: string;
-  metadata?: { title?: string; doi?: string };
+  metadata?: { title?: string; doi?: string; version?: string };
 };
 
 function extractRecordDoi(record: RdmRecord | null): string | undefined {


### PR DESCRIPTION
## Summary by Sourcery

Implement poster versioning across dashboard editing, metadata review, discovery, and Zenodo publication while preserving version-family visibility and lifecycle behavior.

New Features:
- Add version-aware editing and publishing for manually submitted posters, including draft preparation, metadata review, extraction progress, retries, and version history.
- Allow poster versions to be published as new versions of existing Zenodo records with inherited deposition and license context.
- Display poster version history and support navigating between published versions on discovery pages.

Bug Fixes:
- Ensure discovery listings, facets, statistics, and sitemaps count and expose only the latest published version of each poster family.
- Preserve poster-family likes and canonical discovery links across versions.
- Improve DOI resolution for Zenodo records and validate award metadata before publication.
- Prevent deletion of in-progress or already-published version drafts and clean up linked Zenodo drafts when discarding edits.

Enhancements:
- Add dashboard handling for tombstoned posters, including filtering, reason display, and family-wide administrative tombstoning and restoration.
- Improve thumbnail generation, storage promotion, and publication recovery for versioned posters.
- Consolidate poster-family and version-sequence handling across poster, discovery, and publication APIs.